### PR TITLE
Make short app name translatable

### DIFF
--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -54,7 +54,7 @@ public partial class Program
         _mainWindowController = new MainWindowController();
         _mainWindowController.AppInfo.ID = "org.nickvision.money";
         _mainWindowController.AppInfo.Name = "Nickvision Denaro";
-        _mainWindowController.AppInfo.ShortName = "Denaro";
+        _mainWindowController.AppInfo.ShortName = _mainWindowController.Localizer["ShortName"];
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.4.1-beta1";
         _mainWindowController.AppInfo.Changelog = "<ul><li>Added the ability to add extra notes to a transaction</li><li>Added the ability to choose to export all account information or the current filtered view</li><li>Added support for using native digits (instead of just Latin digits) when working with numeric amounts</li><li>Fixed an issue where using custom separators wouldn't parse correctly</li><li>Fixed an issue where CSV files were not exported in the correct format</li><li>Updated and added translations (Thanks to everyone on Weblate)!</li></ul>";

--- a/NickvisionMoney.GNOME/justfile
+++ b/NickvisionMoney.GNOME/justfile
@@ -155,8 +155,10 @@ _translate_meta PREFIX:
     print("\033[1m# Translating desktop and metainfo files\033[0m")
     resx_dir = (Path(os.getcwd()) / '../{{project_name}}.Shared/Resources/').resolve()
     regex = re.compile(r'Strings\.(.+)\.resx')
+    desktop_names = []
     desktop_comments = []
     desktop_keywords = []
+    meta_names = {}
     meta_summaries = {}
     meta_descriptions = {}
     for filename in os.listdir(resx_dir):
@@ -166,6 +168,11 @@ _translate_meta PREFIX:
             tree = ET.parse(f'{resx_dir}/{filename}')
             root = tree.getroot()
             for item in root.findall('./data'):
+                if item.attrib['name'] == 'ShortName':
+                    text = item.find('value').text
+                    if text:
+                        desktop_names.append(f'Name[{lang_code}]={text}')
+                        meta_names[lang_code] = ET.fromstring(f'<name xml:lang="{lang_code}">{text}</name>')
                 if item.attrib['name'] == 'Description':
                     text = item.find('value').text
                     if text:
@@ -189,6 +196,9 @@ _translate_meta PREFIX:
         new_contents = contents.copy()
     j = 0
     for i in range(len(contents)):
+        if contents[i].startswith('Name='):
+            new_contents.insert(j + 1, "\n".join(desktop_names) + "\n")
+            j += 1
         if contents[i].startswith('Comment='):
             new_contents.insert(j + 1, "\n".join(desktop_comments) + "\n")
             j += 1
@@ -202,6 +212,8 @@ _translate_meta PREFIX:
 
     with open('{{builddir}}{{PREFIX}}/share/metainfo/{{app_id}}.metainfo.xml', 'r') as f:
         metainfo = ET.fromstring(''.join(f.readlines()))
+        for i, v in enumerate(meta_names.values()):
+            metainfo.insert(list(metainfo).index(metainfo.find('name')) + i + 1, v)
         for i, v in enumerate(meta_summaries.values()):
             metainfo.insert(list(metainfo).index(metainfo.find('summary')) + i + 1, v)
         for v in meta_descriptions.values():

--- a/NickvisionMoney.Shared/Resources/Strings.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.resx
@@ -18,6 +18,11 @@
 
 	<!--Use: &#xA; for newline-->
 
+	<data name="ShortName" xml:space="preserve">
+		<!--Follow guidelines and/or common practices for your language translations to decide whether the app name should be translated/transliterated-->
+		<value>Denaro</value>
+	</data>
+
 	<data name="Description" xml:space="preserve">
 		<value>Manage your personal finances</value>
 	</data>

--- a/NickvisionMoney.Shared/Resources/Strings.ru.resx
+++ b/NickvisionMoney.Shared/Resources/Strings.ru.resx
@@ -13,6 +13,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <!--Use: &#xA; for newline-->
+	<data name="ShortName" xml:space="preserve">
+		<value>Denaro</value>
+	</data>
   <data name="Description" xml:space="preserve">
 		<value>Управляйте своими личными финансами</value>
   </data>

--- a/NickvisionMoney.WinUI/App.xaml.cs
+++ b/NickvisionMoney.WinUI/App.xaml.cs
@@ -25,7 +25,7 @@ public partial class App : Application
         //AppInfo
         _mainWindowController.AppInfo.ID = "org.nickvision.money";
         _mainWindowController.AppInfo.Name = "Nickvision Denaro";
-        _mainWindowController.AppInfo.ShortName = "Denaro";
+        _mainWindowController.AppInfo.ShortName = _mainWindowController.Localizer["ShortName"];
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.4.1-beta1";
         _mainWindowController.AppInfo.Changelog = "- Added the ability to add extra notes to a transaction\n- Added the ability to choose to export all account information or the current filtered view\n- Added support for using native digits (instead of just Latin digits) when working with numeric amounts\n- Fixed an issue where using custom separators wouldn't parse correctly\n- Fixed an issue where CSV files were not exported in the correct format\n- UI/UX tweaks\n- Updated and added translations (Thanks to everyone on Weblate)!";


### PR DESCRIPTION
Closes #453 
After weblate will upload changes, please add a note to "ShortName" and to "About" (that "{0}" here is "ShortName", but you are free to omit "{0}" in translation and use other word)