### PR TITLE
GNOME - Fix crash with unset locale

### DIFF
--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -45,7 +45,7 @@ public partial class Program
     /// </summary>
     public Program()
     {
-        if (string.IsNullOrEmpty(CultureInfo.CurrentCulture.ToString()))
+        if (CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture))
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-US"); // Fix #465
         }

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -45,7 +45,11 @@ public partial class Program
     /// </summary>
     public Program()
     {
-        if (CultureInfo.CurrentCulture.ToString() == "ar-RG")
+        if (string.IsNullOrEmpty(CultureInfo.CurrentCulture.ToString()))
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US"); // Fix #465
+        }
+        else if (CultureInfo.CurrentCulture.ToString() == "ar-RG")
         {
             CultureInfo.CurrentCulture = new CultureInfo("ar-EG"); // Fix #211
         }


### PR DESCRIPTION
Closes #465 
When locale is unknown, it's now set to en_US.
Tested with LC_ALL=C and also in Alpine distrobox.