### PR TITLE
help-overlay: Fix two groups title seems empty

### DIFF
--- a/NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp
+++ b/NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp
@@ -30,7 +30,7 @@ Gtk.ShortcutsWindow _root {
     }
 
     Gtk.ShortcutsGroup {
-      title: _("AccountActions.GTK");
+      title: _("AccountActions");
 
       Gtk.ShortcutsShortcut {
         title: _("Transfer");
@@ -62,7 +62,7 @@ Gtk.ShortcutsWindow _root {
     }
 
     Gtk.ShortcutsGroup {
-      title: _("Application");
+      title: _("Application.Shortcut");
 
       Gtk.ShortcutsShortcut {
         title: _("Preferences");


### PR DESCRIPTION
This patch makes two help-overlay group titles visible.

Before
![before](https://github.com/NickvisionApps/Denaro/assets/6218679/97ce499d-47be-4b4d-8f4a-2eab049a5139)

After
![after](https://github.com/NickvisionApps/Denaro/assets/6218679/aa2aeaad-a94e-43e7-9fa4-00025bb66076)
