### PR TITLE
Fix An Issue Where Group Filter Was Reactivated

### DIFF
--- a/NickvisionMoney.GNOME/Blueprints/group_row.blp
+++ b/NickvisionMoney.GNOME/Blueprints/group_row.blp
@@ -5,7 +5,7 @@ Adw.ActionRow _root {
   use-markup: false;
   title-lines: 1;
   subtitle-lines: 2;
-  activatable-widget: _editButton;
+  activatable-widget: _filterCheckButton;
   
   [prefix]
   Gtk.Overlay _filterOverlay {

--- a/NickvisionMoney.GNOME/Controls/GroupRow.cs
+++ b/NickvisionMoney.GNOME/Controls/GroupRow.cs
@@ -97,7 +97,7 @@ public partial class GroupRow : Adw.ActionRow, IGroupRowControl
             var luma = color.Red * 0.2126 + color.Green * 0.7152 + color.Blue * 0.0722;
             _filterCheckButton.AddCssClass(luma > 0.5 ? "group-filter-check-dark" : "group-filter-check-light");
             _filterCheckButton.RemoveCssClass(luma > 0.5 ? "group-filter-check-light" : "group-filter-check-dark");
-            _filterCheckButton.SetActive(filterActive);
+            _filterCheckButton.SetActive(_filterActive);
             //Amount Label
             _amountLabel.SetLabel($"{(_group.Balance >= 0 ? "+  " : "-  ")}{_group.Balance.ToAmountString(_cultureAmount, _useNativeDigits)}");
             _amountLabel.AddCssClass(_group.Balance >= 0 ? "denaro-income" : "denaro-expense");

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -65,7 +65,7 @@ public partial class Program
         _mainWindowController.AppInfo.ShortName = _mainWindowController.Localizer["ShortName"];
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.5.0-next";
-        _mainWindowController.AppInfo.Changelog = "<ul><li>Fixed an issue where Denaro would crash on systems with unconfigured locales</li><li>Fixed an issue where PDF exporting failed for accounts with many receipts</li><li>Error messages will be shown if Denaro attempts to access inaccessible files instead of crashing</li><li>Updated and added translations (Thanks to everyone on Weblate)!</li></ul>";
+        _mainWindowController.AppInfo.Changelog = "<ul><li>Fixed an issue where Denaro would crash on systems with unconfigured locales</li><li>Fixed an issue where PDF exporting failed for accounts with many receipts</li><li>Fixed an issue where a group's filter was reactivated when a transaction was added to that group</li><li>Error messages will be shown if Denaro attempts to access inaccessible files instead of crashing</li><li>Updated and added translations (Thanks to everyone on Weblate)!</li></ul>";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/NickvisionApps/Denaro");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/NickvisionApps/Denaro/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/NickvisionApps/Denaro/discussions");

--- a/NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in
+++ b/NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in
@@ -51,6 +51,7 @@
       <description>
         <p>- Fixed an issue where Denaro would crash on systems with unconfigured locales</p>
         <p>- Fixed an issue where PDF exporting failed for accounts with many receipts</p>
+        <p>- Fixed an issue where a group's filter was reactivated when a transaction was added to that group</p>
         <p>- Error messages will be shown if Denaro attempts to access inaccessible files instead of crashing</p>
         <p>- Updated translations (Thanks to everyone on Weblate)!</p>
       </description>


### PR DESCRIPTION
Fixes #501 

Found the bug where a group's filter was reactivated when a transaction was added to the group.

> but show a toast notification when a transaction gets added to a hidden group.

I don't believe this is needed because if a group's filter is not active, and then a transaction is added to said group, that transaction will just disappear from the list (as the filter is not active), but the group row's amount will update with the new transaction added to it, thus confirming the addition of the transaction to the group, not needed a notification.