### PR TITLE
Tags

### DIFF
--- a/NickvisionMoney.GNOME/Blueprints/account_view.blp
+++ b/NickvisionMoney.GNOME/Blueprints/account_view.blp
@@ -198,7 +198,7 @@ Adw.Bin _root {
             }
           };
 
-          Adw.Bin {
+          Adw.Bin _tagsBin {
             Gtk.FlowBox _tagsFlowBox {
               valign: start;
               margin-top: 6;

--- a/NickvisionMoney.GNOME/Blueprints/account_view.blp
+++ b/NickvisionMoney.GNOME/Blueprints/account_view.blp
@@ -172,7 +172,41 @@ Adw.Bin _root {
             styles ["boxed-list"]
           }
         }
-        
+
+        Adw.PreferencesGroup {
+          title: _("Tags");
+          header-suffix: Gtk.Box {
+            Gtk.Button _resetTagsFilterButton {
+              icon-name: "edit-select-all-symbolic";
+              tooltip-text: _("Select All Tags Filters");
+
+              styles ["flat"]
+            }
+
+            Gtk.Button _unselectAllTagsFilterButton {
+              icon-name: "edit-select-none-symbolic";
+              tooltip-text: _("Unselect Tags Filters");
+
+              styles ["flat"]
+            }
+          };
+
+          Adw.Bin {
+            Gtk.FlowBox _tagsFlowBox {
+              valign: start;
+              margin-top: 6;
+              margin-start: 6;
+              margin-end: 6;
+              margin-bottom: 6;
+              column-spacing: 2;
+              row-spacing: 2;
+              selection-mode: none;
+            }
+
+            styles ["card"]
+          }
+        }
+
         Adw.PreferencesGroup {
           title: _("Calendar");
           header-suffix: Gtk.Box 

--- a/NickvisionMoney.GNOME/Blueprints/account_view.blp
+++ b/NickvisionMoney.GNOME/Blueprints/account_view.blp
@@ -176,6 +176,13 @@ Adw.Bin _root {
         Adw.PreferencesGroup {
           title: _("Tags");
           header-suffix: Gtk.Box {
+            Gtk.Button _toggleTagsButton {
+              tooltip-text: _("Toggle Tags Visibility");
+              icon-name: "view-conceal-symbolic";
+
+              styles ["flat"]
+            }
+          
             Gtk.Button _resetTagsFilterButton {
               icon-name: "edit-select-all-symbolic";
               tooltip-text: _("Select All Tags Filters");

--- a/NickvisionMoney.GNOME/Blueprints/account_view.blp
+++ b/NickvisionMoney.GNOME/Blueprints/account_view.blp
@@ -369,53 +369,54 @@ Adw.Bin _root {
             }
             
             Gtk.Box {
-              orientation: horizontal;
+              orientation: vertical;
               
               Adw.PreferencesGroup _transactionsGroup {
                 title: _("Transactions");
-                margin-top: 6;
+                margin-top: 8;
                 margin-start: 10;
                 margin-end: 10;
-                margin-bottom: 10;
                 header-suffix: Gtk.Box {
                   orientation: horizontal;
                   spacing: 6;
-                  
+
                   Gtk.DropDown _sortTransactionByDropDown {}
-                  
+
                   Gtk.Box _transactionsHeaderBox {
                     orientation: horizontal;
                     valign: center;
-                    
+
                     Gtk.ToggleButton _sortFirstToLastButton {
                       icon-name: "view-sort-descending-symbolic";
                       tooltip-text: _("Sort From First To Last");
                       active: bind _sortLastToFirstButton.active inverted bidirectional;
                     }
-                    
+
                     Gtk.ToggleButton _sortLastToFirstButton {
                       icon-name: "view-sort-ascending-symbolic";
                       tooltip-text: _("Sort From Last To First");
                     }
-                    
+
                     styles ["linked"]
                   }
                 };
-                
-                Gtk.ScrolledWindow _transactionsScroll {
-                  width-request: 300;
-                  height-request: 360;
-                  min-content-height: 360;
-                  vexpand: true;
-                  
-                  Gtk.FlowBox _transactionsFlowBox {
-                    homogeneous: true;
-                    column-spacing: 10;
-                    row-spacing: 10;
-                    halign: fill;
-                    valign: start;
-                    selection-mode: none;
-                  }
+              }
+
+              Gtk.ScrolledWindow _transactionsScroll {
+                width-request: 300;
+                min-content-height: 142;
+                vexpand: true;
+
+                Gtk.FlowBox _transactionsFlowBox {
+                  margin-start: 10;
+                  margin-end: 10;
+                  margin-bottom: 62;
+                  homogeneous: true;
+                  column-spacing: 10;
+                  row-spacing: 10;
+                  halign: fill;
+                  valign: start;
+                  selection-mode: none;
                 }
               }
             }

--- a/NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp
+++ b/NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp
@@ -195,6 +195,56 @@ Adw.Window _root {
                         styles ["color-dropdown"]
                       }
                     }
+
+                    Adw.ActionRow {
+                      title: _("Tags");
+
+                      [suffix]
+                      Gtk.MenuButton _tagsButton {
+                        valign: center;
+                        direction: none;
+                        popover: Gtk.Popover {
+                          Gtk.Box {
+                            orientation: vertical;
+                            spacing: 6;
+
+                            Gtk.ScrolledWindow _tagsScrolledWindow {
+                              hscrollbar-policy: never;
+                              height-request: 124;
+                              width-request: 300;
+
+                              Gtk.FlowBox _tagsFlowBox {
+                                valign: start;
+                                margin-top: 4;
+                                margin-start: 4;
+                                margin-end: 4;
+                                column-spacing: 2;
+                                row-spacing: 2;
+                                selection-mode: none;
+                              }
+
+                              styles ["card"]
+                            }
+
+                            Gtk.Box {
+                              Gtk.Entry _addTagEntry {
+                                hexpand: true;
+                                placeholder-text: "Enter a new tag name...";
+                              }
+
+                              Gtk.Button _addTagButton {
+                                child: Adw.ButtonContent {
+                                  label: _("Add Tag");
+                                  icon-name: "list-add-symbolic";
+                                };
+                              }
+
+                              styles ["linked"]
+                            }
+                          }
+                        };
+                      }
+                    }
                   }
 
                   Adw.PreferencesGroup {

--- a/NickvisionMoney.GNOME/Blueprints/transaction_row.blp
+++ b/NickvisionMoney.GNOME/Blueprints/transaction_row.blp
@@ -26,6 +26,7 @@ Gtk.FlowBoxChild _root {
       
         Gtk.Button _editButton {
           icon-name: "document-edit-symbolic";
+          halign: end;
           valign: center;
           tooltip-text: _("Edit Transaction");
         

--- a/NickvisionMoney.GNOME/Controls/TagButton.cs
+++ b/NickvisionMoney.GNOME/Controls/TagButton.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace NickvisionMoney.GNOME.Controls;
+
+public class TagButton : Gtk.ToggleButton
+{
+    public int Index;
+    
+    public event EventHandler<int> OnAddTag;
+    public event EventHandler<int> OnRemoveTag;
+    
+    public TagButton(int index, string tag)
+    {
+        Index = index;
+        SetLabel(tag);
+        OnToggled += (sender, e) =>
+        {
+            if (GetActive())
+            {
+                OnAddTag?.Invoke(this, Index);
+            }
+            else
+            {
+                OnRemoveTag?.Invoke(this, Index);
+            }
+        };
+    }
+}

--- a/NickvisionMoney.GNOME/Controls/TagButton.cs
+++ b/NickvisionMoney.GNOME/Controls/TagButton.cs
@@ -2,27 +2,33 @@ using System;
 
 namespace NickvisionMoney.GNOME.Controls;
 
+/// <summary>
+/// Tag toggle button
+/// </summary>
 public class TagButton : Gtk.ToggleButton
 {
-    public int Index;
+    /// <summary>
+    /// Tag index in a list of all tags in an account
+    /// </summary>
+    public int Index { get; init; }
+    /// <summary>
+    /// Tag string
+    /// </summary>
+    public string Tag { get; init; }
     
-    public event EventHandler<int> OnAddTag;
-    public event EventHandler<int> OnRemoveTag;
+    /// <summary>
+    /// Occurs when toggle state has changed
+    /// </summary>
+    public event EventHandler<(int Index, bool Filter)> FilterChanged;
     
+    /// <summary>
+    /// Construct TagButton
+    /// </summary>
     public TagButton(int index, string tag)
     {
         Index = index;
+        Tag = tag;
         SetLabel(tag);
-        OnToggled += (sender, e) =>
-        {
-            if (GetActive())
-            {
-                OnAddTag?.Invoke(this, Index);
-            }
-            else
-            {
-                OnRemoveTag?.Invoke(this, Index);
-            }
-        };
+        OnToggled += (sender, e) => FilterChanged?.Invoke(this, (Index, GetActive()));
     }
 }

--- a/NickvisionMoney.GNOME/Controls/TagButton.cs
+++ b/NickvisionMoney.GNOME/Controls/TagButton.cs
@@ -8,10 +8,6 @@ namespace NickvisionMoney.GNOME.Controls;
 public class TagButton : Gtk.ToggleButton
 {
     /// <summary>
-    /// Tag index in a list of all tags in an account
-    /// </summary>
-    public int Index { get; init; }
-    /// <summary>
     /// Tag string
     /// </summary>
     public string Tag { get; init; }
@@ -19,16 +15,16 @@ public class TagButton : Gtk.ToggleButton
     /// <summary>
     /// Occurs when toggle state has changed
     /// </summary>
-    public event EventHandler<(int Index, bool Filter)> FilterChanged;
+    public event EventHandler<(string Tag, bool Filter)>? FilterChanged;
     
     /// <summary>
     /// Construct TagButton
     /// </summary>
-    public TagButton(int index, string tag)
+    /// <param name="tag">The tag</param>
+    public TagButton(string tag)
     {
-        Index = index;
         Tag = tag;
         SetLabel(tag);
-        OnToggled += (sender, e) => FilterChanged?.Invoke(this, (Index, GetActive()));
+        OnToggled += (sender, e) => FilterChanged?.Invoke(this, (Tag, GetActive()));
     }
 }

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -44,6 +44,7 @@ public partial class Program
         _mainWindowController = new MainWindowController(args);
         _mainWindowController.AppInfo.Changelog =
             @"* Added graph visuals to the Account view as well as in exported PDFs
+              * Added tags that can be added to transactions for better management and filtering
               * Added the option to select the entire current month as the date range filter
               * Improved the transaction description suggestion algorithm with fuzzy search
               * Fixed an issue where the help button in the import toast was not working

--- a/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
+++ b/NickvisionMoney.GNOME/Resources/org.nickvision.money.css
@@ -17,10 +17,9 @@
   background-color: #00000000;
 }
 
-.account-tag {
+.tag {
   border-radius: 20px;
   font-size: 12px;
-  padding: 1px 12px;
 }
 
 .greeting-title {
@@ -100,10 +99,10 @@ row.error button.circular {
 }
 
 /* Transactions header box */
-.transactions-header {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-bottom-color: @borders;
+.transactions-scroll {
+  border-top-style: solid;
+  border-top-width: 1px;
+  border-top-color: @borders;
 }
 
 /* Group Checkbutton */

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -295,11 +295,11 @@ public partial class AccountView : Adw.Bin
             {
                 if (_transactionsScrollAdjustment.GetValue() == 0.0)
                 {
-                    _transactionsHeaderBox.RemoveCssClass("transactions-header");
+                    _transactionsScroll.RemoveCssClass("transactions-scroll");
                 }
                 else
                 {
-                    _transactionsHeaderBox.AddCssClass("transactions-header");
+                    _transactionsScroll.AddCssClass("transactions-scroll");
                 }
             }
         };

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -146,9 +146,9 @@ public partial class AccountView : Adw.Bin
         //Search Description Text
         _searchDescriptionEntry.OnSearchChanged += (sender, e) => _controller.SearchDescription = _searchDescriptionEntry.GetText();
         //Account Income
-        _incomeCheck.OnToggled += (Gtk.CheckButton sender, EventArgs e) => _controller.UpdateFilterValue(-3, _incomeCheck.GetActive());
+        _incomeCheck.OnToggled += (Gtk.CheckButton sender, EventArgs e) => _controller.UpdateGroupFilterValue(-3, _incomeCheck.GetActive());
         //Account Expense
-        _expenseCheck.OnToggled += (Gtk.CheckButton sender, EventArgs e) => _controller.UpdateFilterValue(-2, _expenseCheck.GetActive());
+        _expenseCheck.OnToggled += (Gtk.CheckButton sender, EventArgs e) => _controller.UpdateGroupFilterValue(-2, _expenseCheck.GetActive());
         //Button Reset Overview Filter
         _resetOverviewFilterButton.OnClicked += OnResetOverviewFilter;
         //Button Toggle Groups
@@ -158,9 +158,9 @@ public partial class AccountView : Adw.Bin
             OnToggleGroups();
         };
         //Button Reset Groups Filter
-        _resetGroupsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetGroupsFilter();
+        _resetGroupsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetGroupFilters();
         //Button Reset Groups Filter
-        _unselectAllGroupsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.UnselectAllGroupsFilter();
+        _unselectAllGroupsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.UnselectAllGroupFilters();
         //Tags FlowBox
         _tagsFlowBox.SetSortFunc((box1, box2) =>
         {
@@ -173,9 +173,9 @@ public partial class AccountView : Adw.Bin
             return string.Compare(tag1.Tag, tag2.Tag);
         });
         //Button Reset Tags Filter
-        _resetTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetTagsFilter();
+        _resetTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetTagFilters();
         //Button Reset Tags Filter
-        _unselectAllTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.UnselectAllTagsFilter();
+        _unselectAllTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.UnselectAllTagFilters();
         //Calendar Widget
         _calendar.OnPrevMonth += OnCalendarMonthYearChanged;
         _calendar.OnPrevYear += OnCalendarMonthYearChanged;
@@ -565,7 +565,7 @@ public partial class AccountView : Adw.Bin
     /// <param name="e">ModelEventArgs</param>
     private bool CreateTagButton(ModelEventArgs<string> e)
     {
-        var tagButton = new TagButton(e.Position!.Value, e.Model);
+        var tagButton = new TagButton(e.Model);
         _tagButtons.Add(tagButton);
         tagButton.SetActive(true);
         tagButton.FilterChanged += UpdateTagFilter;
@@ -1078,14 +1078,14 @@ public partial class AccountView : Adw.Bin
     /// </summary>
     /// <param name="sender">object?</param>
     /// <param name="e">The id of the group who's filter changed and whether to filter or not</param>
-    private void UpdateGroupFilter(object? sender, (uint Id, bool Filter) e) => _controller.UpdateFilterValue((int)e.Id, e.Filter);
+    private void UpdateGroupFilter(object? sender, (uint Id, bool Filter) e) => _controller.UpdateGroupFilterValue((int)e.Id, e.Filter);
 
     /// <summary>
     /// Occurs when the tagfilter is changed
     /// </summary>
     /// <param name="sender">object?</param>
-    /// <param name="e">The index of the tag who's filter changed and whether to filter or not</param>
-    private void UpdateTagFilter(object? sender, (int Index, bool Filter) e) => _controller.UpdateTagFilter(e.Index, e.Filter);
+    /// <param name="e">The tag and whether to filter or not</param>
+    private void UpdateTagFilter(object? sender, (string Tag, bool Filter) e) => _controller.UpdateTagFilter(e.Tag, e.Filter);
 
     /// <summary>
     /// Occurs when the user presses the button to show/hide groups

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -72,6 +72,7 @@ public partial class AccountView : Adw.Bin
     [Gtk.Connect] private readonly Gtk.Button _toggleTagsButton;
     [Gtk.Connect] private readonly Gtk.Button _resetTagsFilterButton;
     [Gtk.Connect] private readonly Gtk.Button _unselectAllTagsFilterButton;
+    [Gtk.Connect] private readonly Adw.Bin _tagsBin;
     [Gtk.Connect] private readonly Gtk.FlowBox _tagsFlowBox;
     [Gtk.Connect] private readonly Gtk.Calendar _calendar;
     [Gtk.Connect] private readonly Gtk.Button _selectMonthButton;
@@ -1110,7 +1111,7 @@ public partial class AccountView : Adw.Bin
     private void OnToggleTags()
     {
         _toggleTagsButton.SetIconName(!_controller.ShowTagsList ? "view-reveal-symbolic" : "view-conceal-symbolic");
-        _tagsFlowBox.SetVisible(_controller.ShowTagsList);
+        _tagsBin.SetVisible(_controller.ShowTagsList);
     }
 
     /// <summary>

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -52,6 +52,7 @@ public partial class AccountView : Adw.Bin
     private readonly Gtk.ShortcutController _shortcutController;
     private readonly Action<string> _updateSubtitle;
     private Dictionary<uint, GroupRow> _groupRows;
+    private List<TagButton> _tagButtons;
     private Dictionary<uint, TransactionRow> _transactionRows;
     private uint _currentGraphPage;
 
@@ -68,6 +69,9 @@ public partial class AccountView : Adw.Bin
     [Gtk.Connect] private readonly Gtk.Button _resetGroupsFilterButton;
     [Gtk.Connect] private readonly Gtk.Button _unselectAllGroupsFilterButton;
     [Gtk.Connect] private readonly Gtk.ListBox _groupsList;
+    [Gtk.Connect] private readonly Gtk.Button _resetTagsFilterButton;
+    [Gtk.Connect] private readonly Gtk.Button _unselectAllTagsFilterButton;
+    [Gtk.Connect] private readonly Gtk.FlowBox _tagsFlowBox;
     [Gtk.Connect] private readonly Gtk.Calendar _calendar;
     [Gtk.Connect] private readonly Gtk.Button _selectMonthButton;
     [Gtk.Connect] private readonly Gtk.Button _resetCalendarFilterButton;
@@ -110,6 +114,7 @@ public partial class AccountView : Adw.Bin
         _isAccountLoading = false;
         _updateSubtitle = updateSubtitle;
         _groupRows = new Dictionary<uint, GroupRow>();
+        _tagButtons = new List<TagButton>();
         _transactionRows = new Dictionary<uint, TransactionRow>();
         _currentGraphPage = 0;
         //Register Controller Events
@@ -117,6 +122,8 @@ public partial class AccountView : Adw.Bin
         _controller.GroupCreated += (sender, e) => GLib.Functions.IdleAdd(0, () => CreateGroupRow(e));
         _controller.GroupDeleted += (sender, e) => GLib.Functions.IdleAdd(0, () => DeleteGroupRow(e));
         _controller.GroupUpdated += (sender, e) => GLib.Functions.IdleAdd(0, () => UpdateGroupRow(e));
+        _controller.TagCreated += (sender, e) => GLib.Functions.IdleAdd(0, () => CreateTagButton(e));
+        _controller.TagUpdated += (sender, e) => GLib.Functions.IdleAdd(0, () => UpdateTagButton(e));
         _controller.TransactionCreated += (sender, e) => GLib.Functions.IdleAdd(0, () => CreateTransactionRow(e));
         _controller.TransactionMoved += (sender, e) => GLib.Functions.IdleAdd(0, () => MoveTransactionRow(e));
         _controller.TransactionDeleted += (sender, e) => GLib.Functions.IdleAdd(0, () => DeleteTransactionRow(e));
@@ -154,6 +161,21 @@ public partial class AccountView : Adw.Bin
         _resetGroupsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetGroupsFilter();
         //Button Reset Groups Filter
         _unselectAllGroupsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.UnselectAllGroupsFilter();
+        //Tags FlowBox
+        _tagsFlowBox.SetSortFunc((box1, box2) =>
+        {
+            var tag1 = (TagButton)box1.GetChild();
+            var tag2 = (TagButton)box2.GetChild();
+            if (tag1.Tag == _("Untagged"))
+            {
+                return -1;
+            }
+            return string.Compare(tag1.Tag, tag2.Tag);
+        });
+        //Button Reset Tags Filter
+        _resetTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetTagsFilter();
+        //Button Reset Tags Filter
+        _unselectAllTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.UnselectAllTagsFilter();
         //Calendar Widget
         _calendar.OnPrevMonth += OnCalendarMonthYearChanged;
         _calendar.OnPrevYear += OnCalendarMonthYearChanged;
@@ -534,6 +556,31 @@ public partial class AccountView : Adw.Bin
         {
             _groupRows[e.Model.Id].UpdateRow(e.Model, _controller.GroupDefaultColor, _controller.CultureForNumberString, e.Active);
         }
+        return false;
+    }
+
+    /// <summary>
+    /// Creates a tag and adds it to the view
+    /// </summary>
+    /// <param name="e">ModelEventArgs</param>
+    private bool CreateTagButton(ModelEventArgs<string> e)
+    {
+        var tagButton = new TagButton(e.Position!.Value, e.Model);
+        _tagButtons.Add(tagButton);
+        tagButton.SetActive(true);
+        tagButton.FilterChanged += UpdateTagFilter;
+        _tagsFlowBox.Append(tagButton);
+        _tagsFlowBox.InvalidateSort();
+        return false;
+    }
+
+    /// <summary>
+    /// Updates a tag button
+    /// </summary>
+    /// <param name="e">ModelEventArgs</param>
+    private bool UpdateTagButton(ModelEventArgs<string> e)
+    {
+        _tagButtons[e.Position!.Value + 1].SetActive(e.Active);
         return false;
     }
 
@@ -1032,6 +1079,13 @@ public partial class AccountView : Adw.Bin
     /// <param name="sender">object?</param>
     /// <param name="e">The id of the group who's filter changed and whether to filter or not</param>
     private void UpdateGroupFilter(object? sender, (uint Id, bool Filter) e) => _controller.UpdateFilterValue((int)e.Id, e.Filter);
+
+    /// <summary>
+    /// Occurs when the tagfilter is changed
+    /// </summary>
+    /// <param name="sender">object?</param>
+    /// <param name="e">The index of the tag who's filter changed and whether to filter or not</param>
+    private void UpdateTagFilter(object? sender, (int Index, bool Filter) e) => _controller.UpdateTagFilter(e.Index, e.Filter);
 
     /// <summary>
     /// Occurs when the user presses the button to show/hide groups

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -69,6 +69,7 @@ public partial class AccountView : Adw.Bin
     [Gtk.Connect] private readonly Gtk.Button _resetGroupsFilterButton;
     [Gtk.Connect] private readonly Gtk.Button _unselectAllGroupsFilterButton;
     [Gtk.Connect] private readonly Gtk.ListBox _groupsList;
+    [Gtk.Connect] private readonly Gtk.Button _toggleTagsButton;
     [Gtk.Connect] private readonly Gtk.Button _resetTagsFilterButton;
     [Gtk.Connect] private readonly Gtk.Button _unselectAllTagsFilterButton;
     [Gtk.Connect] private readonly Gtk.FlowBox _tagsFlowBox;
@@ -172,6 +173,12 @@ public partial class AccountView : Adw.Bin
             }
             return string.Compare(tag1.Tag, tag2.Tag);
         });
+        //Button Toggle Tags
+        _toggleTagsButton.OnClicked += (sender, e) =>
+        {
+            _controller.ShowTagsList = !_controller.ShowTagsList;
+            OnToggleTags();
+        };
         //Button Reset Tags Filter
         _resetTagsFilterButton.OnClicked += (Gtk.Button sender, EventArgs e) => _controller.ResetTagFilters();
         //Button Reset Tags Filter
@@ -414,6 +421,7 @@ public partial class AccountView : Adw.Bin
             _sortLastToFirstButton.SetActive(true);
         }
         OnToggleGroups();
+        OnToggleTags();
         OnWindowWidthChanged(null, new WidthChangedEventArgs(_parentWindow.CompactMode));
     }
 
@@ -1092,15 +1100,17 @@ public partial class AccountView : Adw.Bin
     /// </summary>
     private void OnToggleGroups()
     {
-        if (!_controller.ShowGroupsList)
-        {
-            _toggleGroupsButton.SetIconName("view-reveal-symbolic");
-        }
-        else
-        {
-            _toggleGroupsButton.SetIconName("view-conceal-symbolic");
-        }
+        _toggleGroupsButton.SetIconName(!_controller.ShowGroupsList ? "view-reveal-symbolic" : "view-conceal-symbolic");
         _groupsList.SetVisible(_controller.ShowGroupsList);
+    }
+    
+    /// <summary>
+    /// Occurs when the user presses the button to show/hide tags
+    /// </summary>
+    private void OnToggleTags()
+    {
+        _toggleTagsButton.SetIconName(!_controller.ShowTagsList ? "view-reveal-symbolic" : "view-conceal-symbolic");
+        _tagsFlowBox.SetVisible(_controller.ShowTagsList);
     }
 
     /// <summary>

--- a/NickvisionMoney.GNOME/Views/AccountView.cs
+++ b/NickvisionMoney.GNOME/Views/AccountView.cs
@@ -580,7 +580,7 @@ public partial class AccountView : Adw.Bin
     /// <param name="e">ModelEventArgs</param>
     private bool UpdateTagButton(ModelEventArgs<string> e)
     {
-        _tagButtons[e.Position!.Value + 1].SetActive(e.Active);
+        _tagButtons[e.Position!.Value].SetActive(e.Active);
         return false;
     }
 

--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -107,6 +107,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         _dashboardButton.OnToggled += OnToggleDashboard;
         //Header Bar
         _windowTitle.SetTitle(_controller.AppInfo.ShortName);
+        _graphToggleButton.SetActive(_controller.ShowGraphs);
         //Greeting
         _greeting.SetIconName(_controller.ShowSun ? "sun-outline-symbolic" : "moon-outline-symbolic");
         _greeting.SetLabel(_controller.Greeting);
@@ -254,6 +255,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// <returns>True to stop close, else false</returns>
     private bool OnCloseRequested(Gtk.Window sender, EventArgs e)
     {
+        _controller.ShowGraphs = _graphToggleButton.GetActive();
         _controller.Dispose();
         return false;
     }

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -280,6 +280,23 @@ public class AccountViewController : IDisposable
             }
         }
     }
+    
+    /// <summary>
+    /// Whether or not to show the tags section on the account view
+    /// </summary>
+    public bool ShowTagsList
+    {
+        get => _account.Metadata.ShowTagsList;
+
+        set
+        {
+            if (_account.Metadata.ShowTagsList != value)
+            {
+                _account.Metadata.ShowTagsList = value;
+                _account.UpdateMetadata(_account.Metadata);
+            }
+        }
+    }
 
     /// <summary>
     /// The way in which to sort transactions

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -497,11 +497,11 @@ public class AccountViewController : IDisposable
                 GroupCreated?.Invoke(this, new ModelEventArgs<Group>(pair.Value, null, true));
             }
             //Tags
-            TagCreated?.Invoke(this, new ModelEventArgs<string>(_("Untagged"), -1, true));
+            TagCreated?.Invoke(this, new ModelEventArgs<string>(_("Untagged"), 0, true));
             foreach (var tag in _account.Tags)
             {
                 _filterTags.Add(tag);
-                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag), true));
+                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag) + 1, true));
             }
             //Transactions
             _filteredIds = _account.Transactions.Keys.ToList();
@@ -694,7 +694,7 @@ public class AccountViewController : IDisposable
             {
                 _account.Tags.Add(tag);
                 _filterTags.Add(tag);
-                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag), true));
+                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag) + 1, true));
             }
         }
         FilterUIUpdate();
@@ -728,7 +728,7 @@ public class AccountViewController : IDisposable
             {
                 _account.Tags.Add(tag);
                 _filterTags.Add(tag);
-                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag), true));
+                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag) + 1, true));
             }
         }
         FilterUIUpdate();
@@ -775,7 +775,7 @@ public class AccountViewController : IDisposable
             {
                 _account.Tags.Add(tag);
                 _filterTags.Add(tag);
-                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag), true));
+                TagCreated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag) + 1, true));
             }
         }
         FilterUIUpdate();
@@ -1115,15 +1115,15 @@ public class AccountViewController : IDisposable
     /// <param name="active">Whether or not the tag filter is active</param>
     public void UpdateTagFilter(int index, bool active)
     {
-        if (index > -1)
+        if (index > 0)
         {
             if (active)
             {
-                _filterTags.Add(_account.Tags[index]);
+                _filterTags.Add(_account.Tags[index - 1]);
             }
             else
             {
-                _filterTags.Remove(_account.Tags[index]);
+                _filterTags.Remove(_account.Tags[index - 1]);
             }
         }
         else
@@ -1139,11 +1139,11 @@ public class AccountViewController : IDisposable
     public void ResetTagsFilter()
     {
         _filterUntagged = true;
-        TagUpdated?.Invoke(this, new ModelEventArgs<string>(_("Untagged"), -1, true));
+        TagUpdated?.Invoke(this, new ModelEventArgs<string>(_("Untagged"), 0, true));
         _filterTags = new List<string>(_account.Tags);
         foreach (var tag in _account.Tags)
         {
-            TagUpdated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag), true));
+            TagUpdated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag) + 1, true));
         }
         FilterUIUpdate();
     }
@@ -1154,11 +1154,11 @@ public class AccountViewController : IDisposable
     public void UnselectAllTagsFilter()
     {
         _filterUntagged = false;
-        TagUpdated?.Invoke(this, new ModelEventArgs<string>(_("Untagged"), -1, false));
+        TagUpdated?.Invoke(this, new ModelEventArgs<string>(_("Untagged"), 0, false));
         _filterTags.Clear();
         foreach (var tag in _account.Tags)
         {
-            TagUpdated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag), false));
+            TagUpdated?.Invoke(this, new ModelEventArgs<string>(tag, _account.Tags.IndexOf(tag) + 1, false));
         }
         FilterUIUpdate();
     }
@@ -1197,7 +1197,7 @@ public class AccountViewController : IDisposable
             {
                 continue;
             }
-            if (!_filterTags.Intersect(pair.Value.Tags).Any() && pair.Value.Tags.Count > 0)
+            if (!pair.Value.Tags.Any(x => _filterTags.Contains(x)) && pair.Value.Tags.Count > 0)
             {
                 continue;
             }

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -507,14 +507,14 @@ public class AccountViewController : IDisposable
     /// Creates a new TransactionDialogController for a new transaction
     /// </summary>
     /// <returns>The new TransactionDialogController</returns>
-    public TransactionDialogController CreateTransactionDialogController() => new TransactionDialogController(_account.NextAvailableTransactionId, _account.Transactions, _account.Groups, _account.Metadata.DefaultTransactionType, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
+    public TransactionDialogController CreateTransactionDialogController() => new TransactionDialogController(_account.NextAvailableTransactionId, _account.Transactions, _account.Groups, _account.Tags, _account.Metadata.DefaultTransactionType, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
 
     /// <summary>
     /// Creates a new TransactionDialogController for an existing transaction
     /// </summary>
     /// <param name="id">The id of the existing transaction</param>
     /// <returns>The TransactionDialogController for the existing transaction</returns>
-    public TransactionDialogController CreateTransactionDialogController(uint id) => new TransactionDialogController(_account.Transactions[id], _account.Transactions, _account.Groups, true, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
+    public TransactionDialogController CreateTransactionDialogController(uint id) => new TransactionDialogController(_account.Transactions[id], _account.Transactions, _account.Groups, _account.Tags, true, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
 
     /// <summary>
     /// Creates a new TransactionDialogController for a copy transaction
@@ -537,7 +537,7 @@ public class AccountViewController : IDisposable
             RepeatFrom = source.RepeatFrom,
             RepeatEndDate = source.RepeatEndDate
         };
-        return new TransactionDialogController(toCopy, _account.Transactions, _account.Groups, false, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
+        return new TransactionDialogController(toCopy, _account.Transactions, _account.Groups, _account.Tags, false, TransactionDefaultColor, CultureForNumberString, CultureForDateString);
     }
 
     /// <summary>

--- a/NickvisionMoney.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionMoney.Shared/Controllers/MainWindowController.cs
@@ -44,6 +44,19 @@ public class MainWindowController : IDisposable
     /// The number of open accounts
     /// </summary>
     public int NumberOfOpenAccounts => _openAccounts.Count;
+    /// <summary>
+    /// Whether or not to show graphs
+    /// </summary>
+    public bool ShowGraphs
+    {
+        get => Configuration.Current.ShowGraphs;
+
+        set
+        {
+            Configuration.Current.ShowGraphs = value;
+            Aura.SaveConfig("config");
+        }
+    }
 
     /// <summary>
     /// Occurs when a notification is sent

--- a/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
@@ -87,23 +87,29 @@ public class TransactionDialogController : IDisposable
     /// The list of group names
     /// </summary>
     public List<string> GroupNames => _groups.Values.OrderBy(x => x.Name == _("Ungrouped") ? " " : x.Name).Select(x => x.Name).ToList();
+    /// <summary>
+    /// The list of tags in the account
+    /// </summary>
+    public List<string> AccountTags;
 
     /// <summary>
     /// Constructs a TransactionDialogController
     /// </summary>
     /// <param name="transaction">The Transaction object represented by the controller</param>
     /// <param name="groups">The list of groups in the account</param>
+    /// <param name="tags">The list of tags in the account</params>
     /// <param name="transactions">The list of transactions in the account</param>
     /// <param name="canCopy">Whether or not the transaction can be copied</param>
     /// <param name="transactionDefaultColor">A default color for the transaction</param>
     /// <param name="cultureNumber">The CultureInfo to use for the amount string</param>
     /// <param name="cultureDate">The CultureInfo to use for the date string</param>
-    internal TransactionDialogController(Transaction transaction, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, bool canCopy, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
+    internal TransactionDialogController(Transaction transaction, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, List<string> tags, bool canCopy, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
     {
         _disposed = false;
         _transactionDefaultColor = transactionDefaultColor;
         _transactions = transactions;
         _groups = groups;
+        AccountTags = tags;
         Transaction = (Transaction)transaction.Clone();
         CanCopy = canCopy;
         IsEditing = canCopy;
@@ -122,17 +128,19 @@ public class TransactionDialogController : IDisposable
     /// </summary>
     /// <param name="id">The id of the new transaction</param>
     /// <param name="groups">The list of groups in the account</param>
+    /// <param name="tags">The list of tags in the account</params>
     /// <param name="transactions">The list of transactions in the account</param>
     /// <param name="transactionDefaultType">A default type for the transaction</param>
     /// <param name="transactionDefaultColor">A default color for the transaction</param>
     /// <param name="cultureNumber">The CultureInfo to use for the amount string</param>
     /// <param name="cultureDate">The CultureInfo to use for the date string</param>
-    internal TransactionDialogController(uint id, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, TransactionType transactionDefaultType, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
+    internal TransactionDialogController(uint id, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, List<string> tags, TransactionType transactionDefaultType, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
     {
         _disposed = false;
         _transactionDefaultColor = transactionDefaultColor;
         _transactions = transactions;
         _groups = groups;
+        AccountTags = tags;
         Transaction = new Transaction(id);
         CanCopy = false;
         IsEditing = false;
@@ -282,12 +290,13 @@ public class TransactionDialogController : IDisposable
     /// <param name="groupName">The new Group name</param>
     /// <param name="rgba">The new rgba string</param>
     /// <param name="useGroupColor">Whether or not to use the group's color instead of the transaction's color</param>
+    /// <param name="tags">List of transaction tags</param>
     /// <param name="amountString">The new amount string</param>
     /// <param name="receiptPath">The new receipt image path</param>
     /// <param name="repeatEndDate">The new repeat end date DateOnly object</param>
     /// <param name="notes">The new notes</param>
     /// <returns>TransactionCheckStatus</returns>
-    public TransactionCheckStatus UpdateTransaction(DateOnly date, string description, TransactionType type, int selectedRepeat, string groupName, string rgba, bool useGroupColor, string amountString, string? receiptPath, DateOnly? repeatEndDate, string notes)
+    public TransactionCheckStatus UpdateTransaction(DateOnly date, string description, TransactionType type, int selectedRepeat, string groupName, string rgba, bool useGroupColor, List<string> tags, string amountString, string? receiptPath, DateOnly? repeatEndDate, string notes)
     {
         TransactionCheckStatus result = 0;
         var amount = 0m;
@@ -331,6 +340,7 @@ public class TransactionDialogController : IDisposable
         Transaction.GroupId = groupName == _("Ungrouped") ? -1 : (int)_groups.FirstOrDefault(x => x.Value.Name == groupName).Key;
         Transaction.RGBA = rgba;
         Transaction.UseGroupColor = useGroupColor;
+        Transaction.Tags = tags;
         Transaction.Receipt = null;
         if (receiptPath != null)
         {

--- a/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
@@ -51,6 +51,10 @@ public class TransactionDialogController : IDisposable
     /// </summary>
     public Transaction Transaction { get; init; }
     /// <summary>
+    /// The list of tags in the account
+    /// </summary>
+    public List<string> AccountTags { get; init; }
+    /// <summary>
     /// Whether or not this transaction can be copied
     /// </summary>
     public bool CanCopy { get; init; }
@@ -87,30 +91,26 @@ public class TransactionDialogController : IDisposable
     /// The list of group names
     /// </summary>
     public List<string> GroupNames => _groups.Values.OrderBy(x => x.Name == _("Ungrouped") ? " " : x.Name).Select(x => x.Name).ToList();
-    /// <summary>
-    /// The list of tags in the account
-    /// </summary>
-    public List<string> AccountTags;
 
     /// <summary>
     /// Constructs a TransactionDialogController
     /// </summary>
     /// <param name="transaction">The Transaction object represented by the controller</param>
     /// <param name="groups">The list of groups in the account</param>
-    /// <param name="tags">The list of tags in the account</params>
+    /// <param name="accountTags">The list of tags in the account</param>
     /// <param name="transactions">The list of transactions in the account</param>
     /// <param name="canCopy">Whether or not the transaction can be copied</param>
     /// <param name="transactionDefaultColor">A default color for the transaction</param>
     /// <param name="cultureNumber">The CultureInfo to use for the amount string</param>
     /// <param name="cultureDate">The CultureInfo to use for the date string</param>
-    internal TransactionDialogController(Transaction transaction, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, List<string> tags, bool canCopy, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
+    internal TransactionDialogController(Transaction transaction, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, List<string> accountTags, bool canCopy, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
     {
         _disposed = false;
         _transactionDefaultColor = transactionDefaultColor;
         _transactions = transactions;
         _groups = groups;
-        AccountTags = tags;
         Transaction = (Transaction)transaction.Clone();
+        AccountTags = new List<string>(accountTags);
         CanCopy = canCopy;
         IsEditing = canCopy;
         CopyRequested = false;
@@ -121,6 +121,7 @@ public class TransactionDialogController : IDisposable
         {
             Transaction.RGBA = _transactionDefaultColor;
         }
+        AccountTags.Remove(AccountTags[0]); //remove untagged
     }
 
     /// <summary>
@@ -128,19 +129,19 @@ public class TransactionDialogController : IDisposable
     /// </summary>
     /// <param name="id">The id of the new transaction</param>
     /// <param name="groups">The list of groups in the account</param>
-    /// <param name="tags">The list of tags in the account</params>
+    /// <param name="accountTags">The list of tags in the account</param>
     /// <param name="transactions">The list of transactions in the account</param>
     /// <param name="transactionDefaultType">A default type for the transaction</param>
     /// <param name="transactionDefaultColor">A default color for the transaction</param>
     /// <param name="cultureNumber">The CultureInfo to use for the amount string</param>
     /// <param name="cultureDate">The CultureInfo to use for the date string</param>
-    internal TransactionDialogController(uint id, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, List<string> tags, TransactionType transactionDefaultType, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
+    internal TransactionDialogController(uint id, Dictionary<uint, Transaction> transactions, Dictionary<uint, Group> groups, List<string> accountTags, TransactionType transactionDefaultType, string transactionDefaultColor, CultureInfo cultureNumber, CultureInfo cultureDate)
     {
         _disposed = false;
         _transactionDefaultColor = transactionDefaultColor;
         _transactions = transactions;
         _groups = groups;
-        AccountTags = tags;
+        AccountTags = new List<string>(accountTags);
         Transaction = new Transaction(id);
         CanCopy = false;
         IsEditing = false;
@@ -151,6 +152,7 @@ public class TransactionDialogController : IDisposable
         //Set Defaults For New Transaction
         Transaction.Type = transactionDefaultType;
         Transaction.RGBA = transactionDefaultColor;
+        AccountTags.Remove(AccountTags[0]); //remove untagged
     }
     
     /// <summary>

--- a/NickvisionMoney.Shared/Docs/html/C/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/C/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/ar/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/ar/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/cs/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/cs/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Každá transakce může patřit pouze do jedné skupiny nebo do žádné (skupina „Neseskupené“).</p></dd>
 <dt class="terms">Barva</dt>
 <dd class="terms"><p class="p">Barva pro transakce. Lze nastavit použití barvy skupiny nebo jedinečné barvy. Při výběru jedinečné barvy bude ve výchozím nastavení nastavena na barvu vybranou v <span class="link"><a href="configuration.html" title="Nastavení">nastavení</a></span>, lze ji ale změnit na libovolnou barvu.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Faktura</dt>
 <dd class="terms"><p class="p">Obrázek faktury za transakci. Můžete nahrát obrázek JPEG nebo PNG nebo dokument PDF, ale bez ohledu na formát bude převeden a uložen jako obrázek JPEG. V případě PDF bude uložena pouze první stránka. Soubor můžete kdykoli odstranit nebo nahrát jiný.</p></dd>
 <dt class="terms">Poznámky</dt>

--- a/NickvisionMoney.Shared/Docs/html/da/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/da/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/de/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/de/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Konfiguration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/es/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/es/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Cada transacción puede pertenecer a un solo grupo o a ninguno (grupo "No agrupado").</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">Un color para la transacción. Puede configurarse para usar un color de grupo o un color único. Al seleccionar un color único, se establecerá por defecto el color seleccionado en la <span class="link"><a href="configuration.html" title="Configuración">configuración</a></span>, pero puede cambiarse a cualquier color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Recibo</dt>
 <dd class="terms"><p class="p">Una imagen de un recibo de transacción. Puede cargar una imagen JPEG o PNG o un documento PDF, pero sin importar el formato, se convertirá y se guardará como una imagen JPEG. En caso de PDF, solo se guardará la primera página. Puede eliminar o cargar otro archivo en cualquier momento.</p></dd>
 <dt class="terms">Notas</dt>

--- a/NickvisionMoney.Shared/Docs/html/et/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/et/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/fi/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/fi/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/fr/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/fr/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Chaque transaction peut appartenir à un ou bien à aucun groupe (groupe « Sans groupe »).</p></dd>
 <dt class="terms">Couleur</dt>
 <dd class="terms"><p class="p">Une couleur pour les transactions. Elle peut être définie pour utiliser un groupe de couleur ou une couleur unique. Lors de la sélection d’une couleur unique, elle sera définie par défaut comme la couleur sélectionnée dans la <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, mais peut être modifiée en n’importe quelle couleur.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Reçu</dt>
 <dd class="terms"><p class="p">Image d’un reçu pour une transaction. Vous pouvez téléverser des images JPEG, PNG ou un document PDF, mais peut importe le format il sera converti et enregistré en tant qu’image JPEG. Dans le cas d’un PDF, seule la première page sera enregistrée. Vous pouvez supprimer le fichier ou en téléverser un autre à tout moment.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/hi/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/hi/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/hr/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/hr/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/id/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/id/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Catatan</dt>

--- a/NickvisionMoney.Shared/Docs/html/it/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/it/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Ciascuna transazione può appartenere a un solo gruppo, oppure nessuno (cioè appartiene al gruppo «Senza gruppo»).</p></dd>
 <dt class="terms">Colore</dt>
 <dd class="terms"><p class="p">Un colore per la transazione. Si può impostare affinché la transazione usi il colore del gruppo a cui appartiene, oppure un colore speciale. Se si sceglie il secondo, verrà inizialmente impostato al colore predefinito selezionato nella <span class="link"><a href="configuration.html" title="Configurazione">configurazione</a></span>, ma può essere cambiato in qualsiasi altro colore.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Ricevuta</dt>
 <dd class="terms"><p class="p">L'immagine di una ricevuta per la transazione. È possibile caricare immagini in formato JPEG o PNG, oppure documenti PDF, ma a prescindere dal formato verrà convertita e salvata come immagine JPEG. Nel caso del PDF, verrà salvata solo la prima pagina. È possibile eliminare o caricare un altro file in qualsiasi momento.</p></dd>
 <dt class="terms">Annotazioni</dt>

--- a/NickvisionMoney.Shared/Docs/html/ja/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/ja/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/nl/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/nl/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Kleur</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuratie">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Factuur</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Aantekeningen</dt>

--- a/NickvisionMoney.Shared/Docs/html/oc/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/oc/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/pl/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/pl/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/pt/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/pt/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/pt_BR/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/pt_BR/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/ru/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/ru/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Каждая транзакция может принадлежать только к одной группе, либо быть без группы (т.е. принадлежать к группе «Несгруппированные»).</p></dd>
 <dt class="terms">Цвет</dt>
 <dd class="terms"><p class="p">Цвет транзакции. Можно либо использовать цвет группы, либо указать собственный цвет. При выборе собственного цвета, по умолчанию он будет соответствовать цвету, указанному в <span class="link"><a href="configuration.html" title="Конфигурация">конфигурации</a></span>, но он может быть изменён на любой другой цвет.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Чек</dt>
 <dd class="terms"><p class="p">Изображение чека транзакции. Вы можете загрузить изображение в формате JPEG или PNG, либо PDF документ, но независимо от формата файл будет конвертирован и сохранён как изображение JPEG. Если вы загрузил PDF, только первая страница будет сохранена. Удалить или загрузить другой файл можно в любой момент.</p></dd>
 <dt class="terms">Заметки</dt>

--- a/NickvisionMoney.Shared/Docs/html/sv/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/sv/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/ta/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/ta/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/tr/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/tr/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/ur/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/ur/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">Receipt</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">Notes</dt>

--- a/NickvisionMoney.Shared/Docs/html/zh_Hans/transaction.html
+++ b/NickvisionMoney.Shared/Docs/html/zh_Hans/transaction.html
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
 <dd class="terms"><p class="p">Each transaction can belong to only one group or none («Ungrouped» group).</p></dd>
 <dt class="terms">Color</dt>
 <dd class="terms"><p class="p">A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <span class="link"><a href="configuration.html" title="Configuration">configuration</a></span>, but can be changed to any color.</p></dd>
+<dt class="terms">Tags</dt>
+<dd class="terms"><p class="p">A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<span class="code">,</span>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p></dd>
 <dt class="terms">收据</dt>
 <dd class="terms"><p class="p">An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p></dd>
 <dt class="terms">注释</dt>

--- a/NickvisionMoney.Shared/Docs/po/ar.po
+++ b/NickvisionMoney.Shared/Docs/po/ar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-11 05:58+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-money/"
@@ -93,11 +93,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -130,8 +130,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -325,10 +325,10 @@ msgstr "اللون المبدئيُّ للمعاملات"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -339,8 +339,8 @@ msgstr "اللون المبدئيُّ للتحويلات"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -426,9 +426,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -726,9 +727,9 @@ msgstr "النوع"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -801,11 +802,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -814,12 +831,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -866,8 +883,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/cs.po
+++ b/NickvisionMoney.Shared/Docs/po/cs.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-06 00:02+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-money/"
@@ -107,11 +107,11 @@ msgstr "Typ účtu"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 "K dispozici jsou 3 typy účtů: 🟣<em>Běžný</em>, 🔵<em>Spořicí</em> a 🟢"
 "<em>Firemní</em>. Typ účtu je pouze užitečné označení, které se zobrazuje v "
@@ -155,8 +155,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 "Pokud je vaše místní prostředí <em>Angličtina (Spojené státy)</em>, symbol "
 "měny bude nastaven na <em>$</em> a <em>1,000.00</em> bude akceptováno jako "
@@ -393,14 +393,15 @@ msgstr "Výchozí barva transakce"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
-"Barva, která bude vybrána jako výchozí při přidání nové <link xref="
-"\"transaction\">transakce</link> s jedinečnou barvou. Její změna neovlivní "
-"existující transakce, i když používají dříve zvolenou výchozí barvu."
+"Barva, která bude vybrána jako výchozí při přidání nové <link "
+"xref=\"transaction\">transakce</link> s jedinečnou barvou. Její změna "
+"neovlivní existující transakce, i když používají dříve zvolenou výchozí "
+"barvu."
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:33
@@ -410,13 +411,13 @@ msgstr "Výchozí barva převodu"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
-"Barva, která bude použita pro transakce vytvořené pomocí <link xref="
-"\"transfer\">převodu</link> . Změna tohoto parametru neovlivní existující "
-"transakce."
+"Barva, která bude použita pro transakce vytvořené pomocí <link "
+"xref=\"transfer\">převodu</link> . Změna tohoto parametru neovlivní "
+"existující transakce."
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:37
@@ -515,13 +516,14 @@ msgstr "Složka zálohy CSV"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
-"Složka, do které budou vaše data po každé změně automaticky <link xref="
-"\"import-export\">exportována jako soubor CSV</link>. Tato funkce nefunguje "
-"pro účty chráněné heslem, protože soubory CSV nelze chránit heslem."
+"Složka, do které budou vaše data po každé změně automaticky <link "
+"xref=\"import-export\">exportována jako soubor CSV</link>. Tato funkce "
+"nefunguje pro účty chráněné heslem, protože soubory CSV nelze chránit heslem."
 
 #. (itstool) path: info/title
 #: yelp/C/import-export.page:8
@@ -873,9 +875,9 @@ msgstr "Typ"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 "<em>Příjem</em> nebo <em>Výdaj</em>. Ve výchozím nastavení se při otevření "
 "dialogu pro přidání nové transakce vybere ta, která byla zvolena v <link "
@@ -970,11 +972,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "Faktura"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -987,12 +1005,12 @@ msgstr ""
 "odstranit nebo nahrát jiný."
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Poznámky"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr "Volně formulovaná textová poznámka, která se připojí k transakci."
 
@@ -1044,8 +1062,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 "Převod neumožňuje vytvářet opakující se transakce ani nastavovat jiné "
 "vlastnosti než částku. Pro vytvořené transakce se použije barva vybraná v "

--- a/NickvisionMoney.Shared/Docs/po/da.po
+++ b/NickvisionMoney.Shared/Docs/po/da.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/de.po
+++ b/NickvisionMoney.Shared/Docs/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-15 18:28+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-money/"
@@ -99,11 +99,11 @@ msgstr "Konto Typ"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -138,8 +138,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -341,10 +341,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -355,8 +355,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -442,9 +442,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -742,9 +743,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -817,11 +818,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -830,12 +847,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -882,8 +899,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/denaro.pot
+++ b/NickvisionMoney.Shared/Docs/po/denaro.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -637,21 +637,31 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
-msgid "An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime."
+msgid "A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing."
 msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:65
-msgid "Notes"
+msgid "Receipt"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:66
+msgid "An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:69
+msgid "Notes"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 

--- a/NickvisionMoney.Shared/Docs/po/es.po
+++ b/NickvisionMoney.Shared/Docs/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-19 19:49+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
 "weblate.org>\n"
@@ -111,18 +111,18 @@ msgstr "Tipo de cuenta"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
-"Hay 3 tipos de cuenta disponibles: 🟣<em>Corriente</em>, 🔵<em>Ahorros</em> y 🟢"
-"<em>Empresas</em>. El tipo de cuenta es sólo una etiqueta útil que se "
+"Hay 3 tipos de cuenta disponibles: 🟣<em>Corriente</em>, 🔵<em>Ahorros</em> "
+"y 🟢<em>Empresas</em>. El tipo de cuenta es sólo una etiqueta útil que se "
 "muestra en la lista de cuentas recientes y no afecta al funcionamiento de la "
 "aplicación ni a lo que se puede hacer con una cuenta. Cada tipo de cuenta "
-"tiene su propio color, estos colores se pueden configurar en la <link xref="
-"\"configuration\">configuración global</link>."
+"tiene su propio color, estos colores se pueden configurar en la <link "
+"xref=\"configuration\">configuración global</link>."
 
 #. (itstool) path: item/title
 #: yelp/C/account.page:37
@@ -162,8 +162,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 "Si su idioma es <em>inglés (EE. UU.)</em>, el símbolo de moneda se "
 "establecerá en <em>$</em> y se aceptará <em>1,000.00</em> como un número "
@@ -410,14 +410,14 @@ msgstr "Color de transacción predeterminado"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
-"Un color que se seleccionará por defecto al agregar una <link xref="
-"\"transaction\">transacción</link> nueva con color único. Cambiar esto no "
-"afectará las transacciones existentes, incluso si usa el color "
+"Un color que se seleccionará por defecto al agregar una <link "
+"xref=\"transaction\">transacción</link> nueva con color único. Cambiar esto "
+"no afectará las transacciones existentes, incluso si usa el color "
 "predeterminado seleccionado previamente."
 
 #. (itstool) path: item/title
@@ -428,13 +428,13 @@ msgstr "Color predeterminado de la transferencia"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
-"Un color que se usará para transacciones creadas usando <link xref=\"transfer"
-"\">transferencia</link>. Cambiar esto no afectará las transacciones "
-"existentes."
+"Un color que se usará para transacciones creadas usando <link "
+"xref=\"transfer\">transferencia</link>. Cambiar esto no afectará las "
+"transacciones existentes."
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:37
@@ -534,9 +534,10 @@ msgstr "Carpeta de copia de seguridad CSV"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 "Una carpeta donde sus datos se <link xref=\"import-export\">exportarán a "
 "CSV</link> después de cada cambio. Esta función no funciona con cuentas "
@@ -674,9 +675,9 @@ msgid ""
 "See <em>Repeat Interval</em> in <link xref=\"transaction\">transaction</"
 "link> page for details about repeat transactions."
 msgstr ""
-"Véase <em>Intervalo de repetición</em> en la página de <link xref="
-"\"transaction\">transacción</link> para obtener más información sobre las "
-"transacciones repetidas."
+"Véase <em>Intervalo de repetición</em> en la página de <link "
+"xref=\"transaction\">transacción</link> para obtener más información sobre "
+"las transacciones repetidas."
 
 #. (itstool) path: item/p
 #: yelp/C/import-export.page:68
@@ -901,9 +902,9 @@ msgstr "Tipo"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 "<em>Ingresos</em> o <em>Gastos</em>. De forma predeterminada, el elegido en "
 "<link xref=\"account\">configuración de la cuenta</link> se seleccionará "
@@ -1000,11 +1001,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "Recibo"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -1017,12 +1034,12 @@ msgstr ""
 "Puede eliminar o cargar otro archivo en cualquier momento."
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Notas"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr "Una nota de texto libre para adjuntar a la transacción."
 
@@ -1080,8 +1097,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 "La transferencia no le permite crear transacciones repetitivas ni establecer "
 "ninguna otra propiedad que no sea la cantidad. El color seleccionado en "

--- a/NickvisionMoney.Shared/Docs/po/et.po
+++ b/NickvisionMoney.Shared/Docs/po/et.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/fi.po
+++ b/NickvisionMoney.Shared/Docs/po/fi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/fr.po
+++ b/NickvisionMoney.Shared/Docs/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-14 01:22+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-money/"
@@ -110,11 +110,11 @@ msgstr "Type de compte"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 "Il y a trois types de comptes possibles : 🟣<em>Chèques</em>, 🔵<em>Épargne</"
 "em> et 🟢<em>Affaires</em>. Le type de compte est uniquement une étiquette "
@@ -161,8 +161,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 "Si votre langue locale est l’<em>Anglais (US)</em>, le symbole monétaire "
 "sera <em>$</em> et <em>1,000.00</em> sera accepté comme une valeur numérique "
@@ -174,8 +174,9 @@ msgid ""
 "If your locale is <em>Italian</em>, currency symbol will be set to <em>€</"
 "em> and <em>1.000,00</em> will be accepted as a valid number."
 msgstr ""
-"Si votre langue locale est l’<em>Italien</em>, le symbole monétaire sera <em>"
-"€</em> et <em>1.000,00</em> sera accepté comme une valeur numérique valide."
+"Si votre langue locale est l’<em>Italien</em>, le symbole monétaire sera "
+"<em>€</em> et <em>1.000,00</em> sera accepté comme une valeur numérique "
+"valide."
 
 #. (itstool) path: item/p
 #: yelp/C/account.page:46
@@ -183,8 +184,9 @@ msgid ""
 "If your locale is <em>Russian</em>, currency symbol will be set to <em>₽</"
 "em> and <em>1000,00</em> will be accepted as a valid number."
 msgstr ""
-"Si votre langue locale est le <em>Russe</em>, le symbole monétaire sera <em>"
-"₽</em> et <em>1000,00</em> sera accepté comme une valeur numérique valide."
+"Si votre langue locale est le <em>Russe</em>, le symbole monétaire sera "
+"<em>₽</em> et <em>1000,00</em> sera accepté comme une valeur numérique "
+"valide."
 
 #. (itstool) path: note/p
 #: yelp/C/account.page:49
@@ -255,8 +257,8 @@ msgid ""
 "An example to understand the difference between a symbol and a code: <em>$</"
 "em> is a symbol, <em>USD</em> is a code."
 msgstr ""
-"Un exemple pour comprendre la différence entre un symbole et un code : <em>"
-"$</em> est un symbole, <em>USD</em> est un code."
+"Un exemple pour comprendre la différence entre un symbole et un code : "
+"<em>$</em> est un symbole, <em>USD</em> est un code."
 
 #. (itstool) path: item/title
 #: yelp/C/account.page:66
@@ -410,10 +412,10 @@ msgstr "Couleur par défaut des transactions"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 "Une couleur qui sera sélectionnée par défaut lors de l’ajout d’une nouvelle "
 "<link xref=\"transaction\">transaction</link> avec une couleur unique. "
@@ -428,12 +430,12 @@ msgstr "Couleur par défaut des transferts"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
-"Une couleur qui sera utilisée pour les transactions créées par un <link xref="
-"\"transfer\">transfert</link>. Changer ce paramètre n’affectera pas les "
+"Une couleur qui sera utilisée pour les transactions créées par un <link "
+"xref=\"transfer\">transfert</link>. Changer ce paramètre n’affectera pas les "
 "transactions existantes."
 
 #. (itstool) path: item/title
@@ -534,12 +536,13 @@ msgstr "Dossier de sauvegarde CSV"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
-"Un dossier où vos données seront automatiquement <link xref=\"import-export"
-"\">exportées au format CSV</link> après chaque modification. Cette "
+"Un dossier où vos données seront automatiquement <link xref=\"import-"
+"export\">exportées au format CSV</link> après chaque modification. Cette "
 "fonctionnalité ne fonctionne pas pour les comptes protégés par mot de passe, "
 "car les fichiers CSV ne peuvent être protégés par un mot de passe."
 
@@ -675,9 +678,9 @@ msgid ""
 "See <em>Repeat Interval</em> in <link xref=\"transaction\">transaction</"
 "link> page for details about repeat transactions."
 msgstr ""
-"Voir <em>Intervalle de répétition</em> dans la page des <link xref="
-"\"transaction\">transactions</link> pour des détails sur les transactions "
-"répétées."
+"Voir <em>Intervalle de répétition</em> dans la page des <link "
+"xref=\"transaction\">transactions</link> pour des détails sur les "
+"transactions répétées."
 
 #. (itstool) path: item/p
 #: yelp/C/import-export.page:68
@@ -908,9 +911,9 @@ msgstr "Type"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 "<em>Revenu</em> ou <em>Dépense</em>. Par défaut la valeur choisie dans les "
 "<link xref=\"account\">Paramètres du compte</link> sera sélectionnée lorsque "
@@ -1008,11 +1011,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "Reçu"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -1026,12 +1045,12 @@ msgstr ""
 "autre à tout moment."
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Notes"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr "Un texte de forme libre qui peut être joint à la transaction."
 
@@ -1089,8 +1108,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 "Le transfert ne vous permet pas de créer des transactions répétées ou de "
 "définir une autre propriété que le montant. La couleur sélectionnée dans la "

--- a/NickvisionMoney.Shared/Docs/po/hi.po
+++ b/NickvisionMoney.Shared/Docs/po/hi.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/hr.po
+++ b/NickvisionMoney.Shared/Docs/po/hr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/id.po
+++ b/NickvisionMoney.Shared/Docs/po/id.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-07 19:40+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -92,11 +92,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -129,8 +129,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -324,10 +324,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -338,8 +338,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -425,9 +425,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -725,9 +726,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -800,11 +801,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -813,12 +830,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Catatan"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -865,8 +882,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/it.po
+++ b/NickvisionMoney.Shared/Docs/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-03 07:50+0000\n"
 "Last-Translator: Davide <davide.ferracin@protonmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-money/"
@@ -112,18 +112,18 @@ msgstr "Tipo di conto"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
-"Sono disponibili tre tipi di conto: 🟣<em>conto corrente</em>, 🔵<em>deposito</"
-"em> and 🟢<em>aziendale</em>. Il tipo di conto è solo un'etichetta, mostrata "
-"nella lista dei conti recenti, che non influisce sul funzionamento "
-"dell'applicazione o sulle azioni disponibili per ciascun conto. Ciascun tipo "
-"di conto ha il suo colore, che può essere configurato nelle <link xref="
-"\"configuration\">impostazioni generali</link>."
+"Sono disponibili tre tipi di conto: 🟣<em>conto corrente</em>, "
+"🔵<em>deposito</em> and 🟢<em>aziendale</em>. Il tipo di conto è solo "
+"un'etichetta, mostrata nella lista dei conti recenti, che non influisce sul "
+"funzionamento dell'applicazione o sulle azioni disponibili per ciascun "
+"conto. Ciascun tipo di conto ha il suo colore, che può essere configurato "
+"nelle <link xref=\"configuration\">impostazioni generali</link>."
 
 #. (itstool) path: item/title
 #: yelp/C/account.page:37
@@ -162,8 +162,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 "Se il proprio formato è <em>Inglese (US)</em>, il simbolo della valuta sarà "
 "impostato su <em>$</em> e <em>1,000.00</em> verrà accettato come un valore "
@@ -409,10 +409,10 @@ msgstr "Colore predefinito delle transazioni"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 "Un colore che verrà selezionato inizialmente all'aggiunta di una nuova <link "
 "xref=\"transaction\">transazione</link> con colore speciale. Cambiare questo "
@@ -427,13 +427,13 @@ msgstr "Colore predefinito delle transazioni"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
-"Un colore che verrà usato per le transazioni create usando i <link xref="
-"\"transfer\">trasferimenti</link>. Cambiare questo colore non avrà effetto "
-"sulle transazioni esistenti."
+"Un colore che verrà usato per le transazioni create usando i <link "
+"xref=\"transfer\">trasferimenti</link>. Cambiare questo colore non avrà "
+"effetto sulle transazioni esistenti."
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:37
@@ -533,14 +533,15 @@ msgstr "Cartella di backup in CSV"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
-"Una cartella in cui i propri dati verranno automaticamente <link xref="
-"\"import-export\">esportati in formato CSV</link> dopo ogni modifica. Questa "
-"funzionalità non è attiva per i file protetti da password, poiché i file CSV "
-"non possono essere protetti in tale modo."
+"Una cartella in cui i propri dati verranno automaticamente <link "
+"xref=\"import-export\">esportati in formato CSV</link> dopo ogni modifica. "
+"Questa funzionalità non è attiva per i file protetti da password, poiché i "
+"file CSV non possono essere protetti in tale modo."
 
 #. (itstool) path: info/title
 #: yelp/C/import-export.page:8
@@ -902,9 +903,9 @@ msgstr "Tipo"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 "<em>Entrate</em> o <em>Uscite</em>. All'apertura della finestra per creare "
 "una nuova transazione, sarà selezionata l'opzione predefinita scelta nelle "
@@ -1002,11 +1003,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "Ricevuta"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -1020,12 +1037,12 @@ msgstr ""
 "in qualsiasi momento."
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Annotazioni"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr "Un testo libero da allegare alla transazione."
 
@@ -1081,8 +1098,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 "I trasferimenti non permettono di creare transazioni ricorrenti o di "
 "impostare altre proprietà oltre all'importo. Il colore scelto nella <link "

--- a/NickvisionMoney.Shared/Docs/po/ja.po
+++ b/NickvisionMoney.Shared/Docs/po/ja.po
@@ -1,11 +1,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-07-09 22:27+0000\n"
 "Last-Translator: Luci Draws <dpkg.luci@protonmail.com>\n"
-"Language-Team: Japanese <https://hosted.weblate.org/projects/"
-"nickvision-money/docs/ja/>\n"
+"Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-"
+"money/docs/ja/>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -92,11 +92,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -129,8 +129,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -324,10 +324,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -338,8 +338,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -425,9 +425,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -725,9 +726,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -800,11 +801,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -813,12 +830,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -865,8 +882,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/nl.po
+++ b/NickvisionMoney.Shared/Docs/po/nl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-04-21 01:38+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-money/"
@@ -92,11 +92,11 @@ msgstr "Accounttype"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -129,8 +129,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -324,10 +324,10 @@ msgstr "Standaard­transactiekleur"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -338,8 +338,8 @@ msgstr "Standaard­overdrachtkleur"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -425,9 +425,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -725,9 +726,9 @@ msgstr "Type"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -800,11 +801,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "Factuur"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -813,12 +830,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Aantekeningen"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -865,8 +882,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/oc.po
+++ b/NickvisionMoney.Shared/Docs/po/oc.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/pl.po
+++ b/NickvisionMoney.Shared/Docs/po/pl.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-money/"
@@ -93,11 +93,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -130,8 +130,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -325,10 +325,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -339,8 +339,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -426,9 +426,10 @@ msgstr "Folder kopii zapasowych CSV"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -726,9 +727,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -801,11 +802,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -814,12 +831,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -866,8 +883,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/pt.po
+++ b/NickvisionMoney.Shared/Docs/po/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-05-28 22:47+0000\n"
 "Last-Translator: Cassio Gomes Pereira <cassiogomes00@gmail.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/nickvision-"
@@ -92,11 +92,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -129,8 +129,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -324,10 +324,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -338,8 +338,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -425,9 +425,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -725,9 +726,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -800,11 +801,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -813,12 +830,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -865,8 +882,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/pt_BR.po
+++ b/NickvisionMoney.Shared/Docs/po/pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-05-28 22:47+0000\n"
 "Last-Translator: Cassio Gomes Pereira <cassiogomes00@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -109,18 +109,18 @@ msgstr "Tipo de Conta"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
-"Existem 3 tipos de conta disponíveis: 🟣<em>Corrente</em>, 🔵<em>Poupança</em> "
-"e 🟢<em>Comercial</em>. O tipo da conta é so um rótulo útil que é mostrado na "
-"lista de contas recentes e não afeta o funcionamento do aplicativo ou o que "
-"pode ser feito com uma conta. Cada tipo de conta possui sua própria cor. "
-"Essas cores podem ser configuradas nas <link xref=\"configuration"
-"\">configurações globais</link>."
+"Existem 3 tipos de conta disponíveis: 🟣<em>Corrente</em>, 🔵<em>Poupança</"
+"em> e 🟢<em>Comercial</em>. O tipo da conta é so um rótulo útil que é "
+"mostrado na lista de contas recentes e não afeta o funcionamento do "
+"aplicativo ou o que pode ser feito com uma conta. Cada tipo de conta possui "
+"sua própria cor. Essas cores podem ser configuradas nas <link "
+"xref=\"configuration\">configurações globais</link>."
 
 #. (itstool) path: item/title
 #: yelp/C/account.page:37
@@ -159,8 +159,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -354,10 +354,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -368,8 +368,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -455,9 +455,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -755,9 +756,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -830,11 +831,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -843,12 +860,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -895,8 +912,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/ru.po
+++ b/NickvisionMoney.Shared/Docs/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-29 18:15+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-money/"
@@ -109,18 +109,18 @@ msgstr "Тип счёта"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 "Доступно 3 типа счетов: 🟣<em>Расчётный</em>, 🔵<em>Сберегательный</em> и 🟢"
 "<em>Бизнес</em>. Тип счёта представляет собой лишь полезную метку, которая "
 "отображается в списке недавних счетов, и никак не влияет на работу "
 "приложения, не меняет ничего в том, как вы можете использовать счёт. У "
-"каждого типа счёта есть свой цвет, цвета можно настроить в <link xref="
-"\"configuration\">глобальной конфигурации</link>."
+"каждого типа счёта есть свой цвет, цвета можно настроить в <link "
+"xref=\"configuration\">глобальной конфигурации</link>."
 
 #. (itstool) path: item/title
 #: yelp/C/account.page:37
@@ -160,8 +160,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 "Если ваш регион <em>Английский (США)</em>, знак <em>$</em> будет символом "
 "валюты, а <em>1,000.00</em> будет приниматься как корректное число."
@@ -404,14 +404,14 @@ msgstr "Цвет транзакции по умолчанию"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
-"Цвет, который будет выбран по умолчанию при создании новой <link xref="
-"\"transaction\">транзакции</link> с собственным цветом. Изменение цвета не "
-"затронет существующие транзакции, даже если они используют цвет, который "
+"Цвет, который будет выбран по умолчанию при создании новой <link "
+"xref=\"transaction\">транзакции</link> с собственным цветом. Изменение цвета "
+"не затронет существующие транзакции, даже если они используют цвет, который "
 "ранее был цветом по умолчанию."
 
 #. (itstool) path: item/title
@@ -422,8 +422,8 @@ msgstr "Цвет перевода средств по умолчанию"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 "Цвет, который будет использован для транзакций, созданных с помощью <link "
@@ -469,8 +469,8 @@ msgid ""
 "A color used to mark <link xref=\"account\">accounts</link> with the "
 "<em>Savings</em> type in a recent accounts list."
 msgstr ""
-"Цвет, которым отмечаются <em>Сберегательные</em> <link xref=\"account"
-"\">счета</link> в списке недавних счетов."
+"Цвет, которым отмечаются <em>Сберегательные</em> <link "
+"xref=\"account\">счета</link> в списке недавних счетов."
 
 #. (itstool) path: item/title
 #: yelp/C/configuration.page:49
@@ -528,12 +528,13 @@ msgstr "Папка резервных копий CSV"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
-"Папка, в которую ваши данные будут автоматически <link xref=\"import-export"
-"\">экспортироваться в формате CSV</link> после каждого изменения. Эта "
+"Папка, в которую ваши данные будут автоматически <link xref=\"import-"
+"export\">экспортироваться в формате CSV</link> после каждого изменения. Эта "
 "функция не работает для счетов, защищённых паролем, т.к. CSV файлы не могут "
 "быть защищены паролем."
 
@@ -820,10 +821,10 @@ msgid ""
 "bit.ly/3GrfEid\">join our Matrix channel</link>."
 msgstr ""
 "Для получения дополнительной помощи посетите <link href=\"https://github.com/"
-"NickvisionApps/Denaro/issues\">раздел проблем</link> или <link href="
-"\"https://github.com/NickvisionApps/Denaro/discussions\">обсуждения</link> "
-"на Github, либо <link href=\"https://bit.ly/3GrfEid\">наш канал в Matrix</"
-"link>."
+"NickvisionApps/Denaro/issues\">раздел проблем</link> или <link "
+"href=\"https://github.com/NickvisionApps/Denaro/discussions\">обсуждения</"
+"link> на Github, либо <link href=\"https://bit.ly/3GrfEid\">наш канал в "
+"Matrix</link>."
 
 #. (itstool) path: info/title
 #: yelp/C/transaction.page:8
@@ -883,8 +884,8 @@ msgid ""
 "em> in <link xref=\"account\">Account page</link> for details."
 msgstr ""
 "Число в формате, корректном для ваших региональных настроек, для "
-"подробностей почитайте о <em>Системной валюте</em> на странице <link xref="
-"\"account\">о счетах</link>."
+"подробностей почитайте о <em>Системной валюте</em> на странице <link "
+"xref=\"account\">о счетах</link>."
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:37
@@ -894,13 +895,13 @@ msgstr "Тип"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 "<em>Доходы</em> или <em>Расходы</em>. По умолчанию при открытии диалога "
-"добавления новой транзакции будет выбран тот тип, что указан в <link xref="
-"\"account\">настройках счёта</link>."
+"добавления новой транзакции будет выбран тот тип, что указан в <link "
+"xref=\"account\">настройках счёта</link>."
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:41
@@ -987,16 +988,33 @@ msgid ""
 msgstr ""
 "Цвет транзакции. Можно либо использовать цвет группы, либо указать "
 "собственный цвет. При выборе собственного цвета, по умолчанию он будет "
-"соответствовать цвету, указанному в <link xref=\"configuration"
-"\">конфигурации</link>, но он может быть изменён на любой другой цвет."
+"соответствовать цвету, указанному в <link "
+"xref=\"configuration\">конфигурации</link>, но он может быть изменён на "
+"любой другой цвет."
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "Чек"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -1010,12 +1028,12 @@ msgstr ""
 "любой момент."
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "Заметки"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr "Текстовая заметка в свободной форме для прикрепления к транзакции."
 
@@ -1069,12 +1087,13 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 "Перевод средств не позволяет создавать повторяющиеся транзакции или задавать "
-"какие-либо другие свойства, кроме суммы. Цвет, выбранный в <link xref="
-"\"configuration\">конфигурации</link>, будет использован для созданных "
+"какие-либо другие свойства, кроме суммы. Цвет, выбранный в <link "
+"xref=\"configuration\">конфигурации</link>, будет использован для созданных "
 "транзакций."
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/sv.po
+++ b/NickvisionMoney.Shared/Docs/po/sv.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/ta.po
+++ b/NickvisionMoney.Shared/Docs/po/ta.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/tr.po
+++ b/NickvisionMoney.Shared/Docs/po/tr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-06-11 05:58+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-money/"
@@ -92,11 +92,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -129,8 +129,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -324,10 +324,10 @@ msgstr "Öntanımlı İşlem Rengi"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -338,8 +338,8 @@ msgstr "Öntanımlı Aktarım Rengi"
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -425,9 +425,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -725,9 +726,9 @@ msgstr "Tür"
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -800,11 +801,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -813,12 +830,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -865,8 +882,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/ur.po
+++ b/NickvisionMoney.Shared/Docs/po/ur.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -89,11 +89,11 @@ msgstr ""
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -126,8 +126,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -321,10 +321,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -335,8 +335,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -422,9 +422,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -722,9 +723,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -797,11 +798,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
-msgid "Receipt"
+msgid "Tags"
 msgstr ""
 
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
+msgid "Receipt"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -810,12 +827,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr ""
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -862,8 +879,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/po/zh_Hans.po
+++ b/NickvisionMoney.Shared/Docs/po/zh_Hans.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-24 04:01+0300\n"
+"POT-Creation-Date: 2023-08-12 00:30+0300\n"
 "PO-Revision-Date: 2023-07-29 12:14+0000\n"
 "Last-Translator: Yuxin Ren <yx_Ren2018@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -92,11 +92,11 @@ msgstr "账户类型"
 #: yelp/C/account.page:34
 msgid ""
 "There are 3 account types available: 🟣<em>Checking</em>, 🔵<em>Savings</em> "
-"and 🟢<em>Business</em>. Account type is only a useful label that is shown in "
-"the list of recent accounts and doesn't affect how the application works or "
-"what you can do with an account. Each account type has its own color, these "
-"colors can be configured in <link xref=\"configuration\">global settings</"
-"link>."
+"and 🟢<em>Business</em>. Account type is only a useful label that is shown "
+"in the list of recent accounts and doesn't affect how the application works "
+"or what you can do with an account. Each account type has its own color, "
+"these colors can be configured in <link xref=\"configuration\">global "
+"settings</link>."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -129,8 +129,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/account.page:44
 msgid ""
-"If your locale is <em>English (US)</em>, currency symbol will be set to <em>"
-"$</em> and <em>1,000.00</em> will be accepted as a valid number."
+"If your locale is <em>English (US)</em>, currency symbol will be set to "
+"<em>$</em> and <em>1,000.00</em> will be accepted as a valid number."
 msgstr ""
 
 #. (itstool) path: item/p
@@ -324,10 +324,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:30
 msgid ""
-"A color that will be selected by default when adding a new <link xref="
-"\"transaction\">transaction</link> with unique color. Changing this will not "
-"affect existing transactions, even if they use previously selected default "
-"color."
+"A color that will be selected by default when adding a new <link "
+"xref=\"transaction\">transaction</link> with unique color. Changing this "
+"will not affect existing transactions, even if they use previously selected "
+"default color."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -338,8 +338,8 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:34
 msgid ""
-"A color that will be used for transactions created using <link xref="
-"\"transfer\">transfer</link>. Changing this will not affect existing "
+"A color that will be used for transactions created using <link "
+"xref=\"transfer\">transfer</link>. Changing this will not affect existing "
 "transactions."
 msgstr ""
 
@@ -425,9 +425,10 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/configuration.page:62
 msgid ""
-"A folder where your data will be automatically <link xref=\"import-export"
-"\">exported to CSV</link> after every change. This feature doesn't work for "
-"password-protected accounts, because CSV files can't be password-protected."
+"A folder where your data will be automatically <link xref=\"import-"
+"export\">exported to CSV</link> after every change. This feature doesn't "
+"work for password-protected accounts, because CSV files can't be password-"
+"protected."
 msgstr ""
 
 #. (itstool) path: info/title
@@ -725,9 +726,9 @@ msgstr ""
 #. (itstool) path: item/p
 #: yelp/C/transaction.page:38
 msgid ""
-"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link xref="
-"\"account\">account settings</link> will be selected when you open a dialog "
-"to add new transaction."
+"<em>Income</em> or <em>Expense</em>. By default the one chosen in <link "
+"xref=\"account\">account settings</link> will be selected when you open a "
+"dialog to add new transaction."
 msgstr ""
 
 #. (itstool) path: item/title
@@ -800,11 +801,27 @@ msgstr ""
 
 #. (itstool) path: item/title
 #: yelp/C/transaction.page:61
+msgid "Tags"
+msgstr ""
+
+#. (itstool) path: item/p
+#: yelp/C/transaction.page:62
+msgid ""
+"A list of tags for transaction. A transaction can have unlimited number of "
+"tags (or have no tags). Tags can contain any characters except comma (<code>,"
+"</code>), and have any length, but they are expected to be short keywords. "
+"Tags are meant to be used for additional filtering when using groups is not "
+"enough. Tags are only saved in transactions themselves, and as result unused "
+"tags disappear automatically on account closing."
+msgstr ""
+
+#. (itstool) path: item/title
+#: yelp/C/transaction.page:65
 msgid "Receipt"
 msgstr "收据"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:62
+#: yelp/C/transaction.page:66
 msgid ""
 "An image of a receipt for transaction. You can upload JPEG or PNG image or "
 "PDF document, but no matter the format it will be converted and saved as "
@@ -813,12 +830,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: item/title
-#: yelp/C/transaction.page:65
+#: yelp/C/transaction.page:69
 msgid "Notes"
 msgstr "注释"
 
 #. (itstool) path: item/p
-#: yelp/C/transaction.page:66
+#: yelp/C/transaction.page:70
 msgid "A freeform text note to attach to transaction."
 msgstr ""
 
@@ -865,8 +882,9 @@ msgstr ""
 #: yelp/C/transfer.page:31
 msgid ""
 "Transfer doesn't allow you to create repeating transactions or set any "
-"properties other than the amount. The color selected in <link xref="
-"\"configuration\">configuration</link> will be used for created transactions."
+"properties other than the amount. The color selected in <link "
+"xref=\"configuration\">configuration</link> will be used for created "
+"transactions."
 msgstr ""
 
 #. (itstool) path: page/p

--- a/NickvisionMoney.Shared/Docs/yelp/C/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/C/transaction.page
@@ -57,6 +57,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/ar/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/ar/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/cs/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/cs/transaction.page
@@ -60,6 +60,10 @@
 		<title>Barva</title>
 		<p>Barva pro transakce. Lze nastavit použití barvy skupiny nebo jedinečné barvy. Při výběru jedinečné barvy bude ve výchozím nastavení nastavena na barvu vybranou v <link xref="configuration">nastavení</link>, lze ji ale změnit na libovolnou barvu.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Faktura</title>
 		<p>Obrázek faktury za transakci. Můžete nahrát obrázek JPEG nebo PNG nebo dokument PDF, ale bez ohledu na formát bude převeden a uložen jako obrázek JPEG. V případě PDF bude uložena pouze první stránka. Soubor můžete kdykoli odstranit nebo nahrát jiný.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/da/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/da/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/de/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/de/transaction.page
@@ -60,6 +60,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/es/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/es/transaction.page
@@ -60,6 +60,10 @@
 		<title>Color</title>
 		<p>Un color para la transacción. Puede configurarse para usar un color de grupo o un color único. Al seleccionar un color único, se establecerá por defecto el color seleccionado en la <link xref="configuration">configuración</link>, pero puede cambiarse a cualquier color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Recibo</title>
 		<p>Una imagen de un recibo de transacción. Puede cargar una imagen JPEG o PNG o un documento PDF, pero sin importar el formato, se convertirá y se guardará como una imagen JPEG. En caso de PDF, solo se guardará la primera página. Puede eliminar o cargar otro archivo en cualquier momento.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/et/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/et/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/fi/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/fi/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/fr/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/fr/transaction.page
@@ -54,6 +54,10 @@
 		<title>Couleur</title>
 		<p>Une couleur pour les transactions. Elle peut être définie pour utiliser un groupe de couleur ou une couleur unique. Lors de la sélection d’une couleur unique, elle sera définie par défaut comme la couleur sélectionnée dans la <link xref="configuration">configuration</link>, mais peut être modifiée en n’importe quelle couleur.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Reçu</title>
 		<p>Image d’un reçu pour une transaction. Vous pouvez téléverser des images JPEG, PNG ou un document PDF, mais peut importe le format il sera converti et enregistré en tant qu’image JPEG. Dans le cas d’un PDF, seule la première page sera enregistrée. Vous pouvez supprimer le fichier ou en téléverser un autre à tout moment.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/hi/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/hi/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/hr/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/hr/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/id/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/id/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/it/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/it/transaction.page
@@ -54,6 +54,10 @@
 		<title>Colore</title>
 		<p>Un colore per la transazione. Si può impostare affinché la transazione usi il colore del gruppo a cui appartiene, oppure un colore speciale. Se si sceglie il secondo, verrà inizialmente impostato al colore predefinito selezionato nella <link xref="configuration">configurazione</link>, ma può essere cambiato in qualsiasi altro colore.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Ricevuta</title>
 		<p>L'immagine di una ricevuta per la transazione. È possibile caricare immagini in formato JPEG o PNG, oppure documenti PDF, ma a prescindere dal formato verrà convertita e salvata come immagine JPEG. Nel caso del PDF, verrà salvata solo la prima pagina. È possibile eliminare o caricare un altro file in qualsiasi momento.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/ja/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/ja/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/nl/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/nl/transaction.page
@@ -54,6 +54,10 @@
 		<title>Kleur</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Factuur</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/oc/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/oc/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/pl/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/pl/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/pt/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/pt/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/pt_BR/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/pt_BR/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/ru/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/ru/transaction.page
@@ -54,6 +54,10 @@
 		<title>Цвет</title>
 		<p>Цвет транзакции. Можно либо использовать цвет группы, либо указать собственный цвет. При выборе собственного цвета, по умолчанию он будет соответствовать цвету, указанному в <link xref="configuration">конфигурации</link>, но он может быть изменён на любой другой цвет.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Чек</title>
 		<p>Изображение чека транзакции. Вы можете загрузить изображение в формате JPEG или PNG, либо PDF документ, но независимо от формата файл будет конвертирован и сохранён как изображение JPEG. Если вы загрузил PDF, только первая страница будет сохранена. Удалить или загрузить другой файл можно в любой момент.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/sv/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/sv/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/ta/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/ta/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/tr/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/tr/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/ur/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/ur/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>Receipt</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Docs/yelp/zh_Hans/transaction.page
+++ b/NickvisionMoney.Shared/Docs/yelp/zh_Hans/transaction.page
@@ -54,6 +54,10 @@
 		<title>Color</title>
 		<p>A color for transaction. Can be set to use either a group color or a unique color. When selecting unique color, it will be set by default to the color selected in <link xref="configuration">configuration</link>, but can be changed to any color.</p>
 	</item>
+    <item>
+        <title>Tags</title>
+        <p>A list of tags for transaction. A transaction can have unlimited number of tags (or have no tags). Tags can contain any characters except comma (<code>,</code>), and have any length, but they are expected to be short keywords. Tags are meant to be used for additional filtering when using groups is not enough. Tags are only saved in transactions themselves, and as result unused tags disappear automatically on account closing.</p>
+    </item>
 	<item>
 		<title>收据</title>
 		<p>An image of a receipt for transaction. You can upload JPEG or PNG image or PDF document, but no matter the format it will be converted and saved as JPEG image. In case of PDF, only the first page will be saved. You can delete or upload another file anytime.</p>

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -106,7 +106,7 @@ public class Account : IDisposable
         Path = path;
         Metadata = new AccountMetadata(System.IO.Path.GetFileNameWithoutExtension(Path), AccountType.Checking);
         Groups = new Dictionary<uint, Group>();
-        Tags = new List<string>();
+        Tags = new List<string>() { _("Untagged") };
         Transactions = new Dictionary<uint, Transaction>();
         NextAvailableGroupId = 1;
         NextAvailableTransactionId = 1;

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -1714,25 +1714,25 @@ public class Account : IDisposable
                         {
                             tbl.ColumnsDefinition(x =>
                             {
-                                //ID, Date, Description, Type, GroupName, Notes, Tags, Amount
+                                //ID, Date, Description, Type, GroupName, Tags, Notes, Amount
                                 x.RelativeColumn(1.5f);
                                 x.RelativeColumn(2);
                                 x.RelativeColumn(3);
                                 x.RelativeColumn(2);
                                 x.RelativeColumn(2);
-                                x.RelativeColumn(3);
                                 x.RelativeColumn(2);
+                                x.RelativeColumn(3);
                                 x.RelativeColumn(2);
                             });
                             //Headers
-                            tbl.Cell().ColumnSpan(7).Background(Colors.Grey.Lighten1).Text(_("Transactions"));
+                            tbl.Cell().ColumnSpan(8).Background(Colors.Grey.Lighten1).Text(_("Transactions"));
                             tbl.Cell().Text(_("Id")).SemiBold();
                             tbl.Cell().Text(_("Date")).SemiBold();
                             tbl.Cell().Text(_("Description")).SemiBold();
                             tbl.Cell().Text(_("Type")).SemiBold();
                             tbl.Cell().Text(_("Group Name")).SemiBold();
-                            tbl.Cell().Text(_("Notes")).SemiBold();
                             tbl.Cell().Text(_("Tags")).SemiBold();
+                            tbl.Cell().Text(_("Notes")).SemiBold();
                             tbl.Cell().AlignRight().Text(_("Amount")).SemiBold();
                             //Data
                             var transactions = Transactions;
@@ -1783,8 +1783,8 @@ public class Account : IDisposable
                                     _ => ""
                                 });
                                 tbl.Cell().Background(hex).Text(pair.Value.GroupId == -1 ? _("Ungrouped") : Groups[(uint)pair.Value.GroupId].Name);
-                                tbl.Cell().Background(hex).Text(pair.Value.Notes);
                                 tbl.Cell().Background(hex).Text(string.Join(", ", pair.Value.Tags));
+                                tbl.Cell().Background(hex).Text(pair.Value.Notes);
                                 tbl.Cell().Background(hex).AlignRight().Text($"{(pair.Value.Type == TransactionType.Income ? "+  " : "−  ")}{pair.Value.Amount.ToAmountString(cultureAmount, Configuration.Current.UseNativeDigits)}");
                             }
                         });

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -532,10 +532,9 @@ public class Account : IDisposable
                 RepeatFrom = readQueryTransactions.IsDBNull(9) ? -1 : readQueryTransactions.GetInt32(9),
                 RepeatEndDate = readQueryTransactions.IsDBNull(10) ? null : (string.IsNullOrEmpty(readQueryTransactions.GetString(10)) ? null : DateOnly.Parse(readQueryTransactions.GetString(10), new CultureInfo("en-US", false))),
                 Notes = readQueryTransactions.IsDBNull(12) ? "" : readQueryTransactions.GetString(12),
-                Tags = readQueryTransactions.IsDBNull(13) ? new List<string>() : readQueryTransactions.GetString(13).Split(',').ToList()
+                Tags = readQueryTransactions.IsDBNull(13) ? new List<string>() : (string.IsNullOrEmpty(readQueryTransactions.GetString(13)) ? new List<string>() : readQueryTransactions.GetString(13).Split(',').ToList())
             };
             Tags.AddRange(transaction.Tags.Where(t => !Tags.Contains(t)));
-            Tags.Sort();
             var receiptString = readQueryTransactions.IsDBNull(8) ? "" : readQueryTransactions.GetString(8);
             if (!string.IsNullOrEmpty(receiptString))
             {
@@ -793,8 +792,6 @@ public class Account : IDisposable
         cmdAddTransaction.Parameters.AddWithValue("$useGroupColor", transaction.UseGroupColor);
         cmdAddTransaction.Parameters.AddWithValue("$notes", transaction.Notes);
         cmdAddTransaction.Parameters.AddWithValue("$tags", string.Join(',', transaction.Tags));
-        Tags.AddRange(transaction.Tags.Where(t => !Tags.Contains(t)));
-        Tags.Sort();
         if (transaction.Receipt != null)
         {
             using var memoryStream = new MemoryStream();
@@ -858,8 +855,6 @@ public class Account : IDisposable
         cmdUpdateTransaction.Parameters.AddWithValue("$useGroupColor", transaction.UseGroupColor);
         cmdUpdateTransaction.Parameters.AddWithValue("$notes", transaction.Notes);
         cmdUpdateTransaction.Parameters.AddWithValue("$tags", string.Join(',', transaction.Tags));
-        Tags.AddRange(transaction.Tags.Where(t => !Tags.Contains(t)));
-        Tags.Sort();
         if (transaction.Receipt != null)
         {
             using var memoryStream = new MemoryStream();

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -959,13 +959,13 @@ public class Account : IDisposable
                     tt.Notes = transaction.Notes;
                     tt.Tags = transaction.Tags;
                     var r = await UpdateTransactionAsync(tt);
-                    success &= r.Successful;
+                    success = success && r.Successful;
                     newTags = newTags.Union(r.NewTags).ToList();
                 }
             }
             var res = await UpdateTransactionAsync(transaction);
-            success &= res.Successful;
-            newTags = newTags.Union(res.NewTags).ToList();
+            success = success && res.Successful;
+            newTags.AddRange(res.NewTags.Where(t => !newTags.Contains(t)));
         }
         else
         {
@@ -978,13 +978,13 @@ public class Account : IDisposable
                     tt.RepeatFrom = -1;
                     tt.RepeatEndDate = null;
                     var r = await UpdateTransactionAsync(tt);
-                    success &= r.Successful;
+                    success = success && r.Successful;
                     newTags = newTags.Union(r.NewTags).ToList();
                 }
             }
             var res = await UpdateTransactionAsync(transaction);
-            success &= res.Successful;
-            newTags = newTags.Union(res.NewTags).ToList();
+            success = success && res.Successful;
+            newTags.AddRange(res.NewTags.Where(t => !newTags.Contains(t)));
         }
         return (success, newTags);
     }

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -342,7 +342,7 @@ public class Account : IDisposable
         }
         //Setup Metadata Table
         using var cmdTableMetadata = _database!.CreateCommand();
-        cmdTableMetadata.CommandText = "CREATE TABLE IF NOT EXISTS metadata (id INTEGER PRIMARY KEY, name TEXT, type INTEGER, useCustomCurrency INTEGER, customSymbol TEXT, customCode TEXT, defaultTransactionType INTEGER, showGroupsList INTEGER, sortFirstToLast INTEGER, sortTransactionsBy INTEGER, customDecimalSeparator TEXT, customGroupSeparator TEXT, customDecimalDigits INTEGER)";
+        cmdTableMetadata.CommandText = "CREATE TABLE IF NOT EXISTS metadata (id INTEGER PRIMARY KEY, name TEXT, type INTEGER, useCustomCurrency INTEGER, customSymbol TEXT, customCode TEXT, defaultTransactionType INTEGER, showGroupsList INTEGER, sortFirstToLast INTEGER, sortTransactionsBy INTEGER, customDecimalSeparator TEXT, customGroupSeparator TEXT, customDecimalDigits INTEGER, showTagsList INTEGER)";
         cmdTableMetadata.ExecuteNonQuery();
         try
         {
@@ -370,6 +370,13 @@ public class Account : IDisposable
             using var cmdTableMetadataUpdate4 = _database.CreateCommand();
             cmdTableMetadataUpdate4.CommandText = "ALTER TABLE metadata ADD COLUMN customDecimalDigits INTEGER";
             cmdTableMetadataUpdate4.ExecuteNonQuery();
+        }
+        catch { }
+        try
+        {
+            using var cmdTableMetadataUpdate5 = _database.CreateCommand();
+            cmdTableMetadataUpdate5.CommandText = "ALTER TABLE metadata ADD COLUMN showTagsList INTEGER";
+            cmdTableMetadataUpdate5.ExecuteNonQuery();
         }
         catch { }
         //Setup Groups Table
@@ -462,11 +469,12 @@ public class Account : IDisposable
             Metadata.CustomCurrencyDecimalSeparator = readQueryMetadata.IsDBNull(10) ? null : readQueryMetadata.GetString(10);
             Metadata.CustomCurrencyGroupSeparator = readQueryMetadata.IsDBNull(11) ? null : (readQueryMetadata.GetString(11) == "empty" ? "" : readQueryMetadata.GetString(11));
             Metadata.CustomCurrencyDecimalDigits = readQueryMetadata.IsDBNull(12) ? null : readQueryMetadata.GetInt32(12);
+            Metadata.ShowTagsList =  readQueryMetadata.IsDBNull(13) ? true : readQueryMetadata.GetBoolean(13);
         }
         else
         {
             using var cmdAddMetadata = _database.CreateCommand();
-            cmdAddMetadata.CommandText = "INSERT INTO metadata (id, name, type, useCustomCurrency, customSymbol, customCode, defaultTransactionType, showGroupsList, sortFirstToLast, sortTransactionsBy, customDecimalSeparator, customGroupSeparator, customDecimalDigits) VALUES (0, $name, $type, $useCustomCurrency, $customSymbol, $customCode, $defaultTransactionType, $showGroupsList, $sortFirstToLast, $sortTransactionsBy, $customDecimalSeparator, $customGroupSeparator, $customDecimalDigits)";
+            cmdAddMetadata.CommandText = "INSERT INTO metadata (id, name, type, useCustomCurrency, customSymbol, customCode, defaultTransactionType, showGroupsList, sortFirstToLast, sortTransactionsBy, customDecimalSeparator, customGroupSeparator, customDecimalDigits, showTagsList) VALUES (0, $name, $type, $useCustomCurrency, $customSymbol, $customCode, $defaultTransactionType, $showGroupsList, $sortFirstToLast, $sortTransactionsBy, $customDecimalSeparator, $customGroupSeparator, $customDecimalDigits, $showTagsList)";
             cmdAddMetadata.Parameters.AddWithValue("$name", Metadata.Name);
             cmdAddMetadata.Parameters.AddWithValue("$type", (int)Metadata.AccountType);
             cmdAddMetadata.Parameters.AddWithValue("$useCustomCurrency", Metadata.UseCustomCurrency);
@@ -479,6 +487,7 @@ public class Account : IDisposable
             cmdAddMetadata.Parameters.AddWithValue("$customDecimalSeparator", Metadata.CustomCurrencyDecimalSeparator ?? "");
             cmdAddMetadata.Parameters.AddWithValue("$customGroupSeparator", string.IsNullOrEmpty(Metadata.CustomCurrencyGroupSeparator) ? "empty" : Metadata.CustomCurrencyGroupSeparator);
             cmdAddMetadata.Parameters.AddWithValue("$customDecimalDigits", Metadata.CustomCurrencyDecimalDigits ?? 2);
+            cmdAddMetadata.Parameters.AddWithValue("$showTagsList", Metadata.ShowGroupsList);
             cmdAddMetadata.ExecuteNonQuery();
         }
         //Get Groups
@@ -658,7 +667,7 @@ public class Account : IDisposable
     public bool UpdateMetadata(AccountMetadata metadata)
     {
         using var cmdUpdateMetadata = _database!.CreateCommand();
-        cmdUpdateMetadata.CommandText = "UPDATE metadata SET name = $name, type = $type, useCustomCurrency = $useCustomCurrency, customSymbol = $customSymbol, customCode = $customCode, defaultTransactionType = $defaultTransactionType, showGroupsList = $showGroupsList, sortFirstToLast = $sortFirstToLast, sortTransactionsBy = $sortTransactionsBy, customDecimalSeparator = $customDecimalSeparator, customGroupSeparator = $customGroupSeparator, customDecimalDigits = $customDecimalDigits WHERE id = 0";
+        cmdUpdateMetadata.CommandText = "UPDATE metadata SET name = $name, type = $type, useCustomCurrency = $useCustomCurrency, customSymbol = $customSymbol, customCode = $customCode, defaultTransactionType = $defaultTransactionType, showGroupsList = $showGroupsList, sortFirstToLast = $sortFirstToLast, sortTransactionsBy = $sortTransactionsBy, customDecimalSeparator = $customDecimalSeparator, customGroupSeparator = $customGroupSeparator, customDecimalDigits = $customDecimalDigits, showTagsList = $showTagsList WHERE id = 0";
         cmdUpdateMetadata.Parameters.AddWithValue("$name", metadata.Name);
         cmdUpdateMetadata.Parameters.AddWithValue("$type", (int)metadata.AccountType);
         cmdUpdateMetadata.Parameters.AddWithValue("$useCustomCurrency", metadata.UseCustomCurrency);
@@ -671,6 +680,7 @@ public class Account : IDisposable
         cmdUpdateMetadata.Parameters.AddWithValue("$customDecimalSeparator", metadata.CustomCurrencyDecimalSeparator ?? "");
         cmdUpdateMetadata.Parameters.AddWithValue("$customGroupSeparator", string.IsNullOrEmpty(metadata.CustomCurrencyGroupSeparator) ? "empty" : metadata.CustomCurrencyGroupSeparator);
         cmdUpdateMetadata.Parameters.AddWithValue("$customDecimalDigits", metadata.CustomCurrencyDecimalDigits ?? 2);
+        cmdUpdateMetadata.Parameters.AddWithValue("$showTagsList", metadata.ShowTagsList);
         if (cmdUpdateMetadata.ExecuteNonQuery() > 0)
         {
             Metadata.Name = metadata.Name;
@@ -680,6 +690,7 @@ public class Account : IDisposable
             Metadata.CustomCurrencyCode = metadata.CustomCurrencyCode;
             Metadata.DefaultTransactionType = metadata.DefaultTransactionType;
             Metadata.ShowGroupsList = metadata.ShowGroupsList;
+            Metadata.ShowTagsList = metadata.ShowTagsList;
             Metadata.SortFirstToLast = metadata.SortFirstToLast;
             Metadata.SortTransactionsBy = metadata.SortTransactionsBy;
             Metadata.CustomCurrencyDecimalSeparator = metadata.CustomCurrencyDecimalSeparator;

--- a/NickvisionMoney.Shared/Models/AccountMetadata.cs
+++ b/NickvisionMoney.Shared/Models/AccountMetadata.cs
@@ -70,6 +70,10 @@ public class AccountMetadata : ICloneable
     /// </summary>
     public bool ShowGroupsList { get; set; }
     /// <summary>
+    /// Whether or not to show the tags section on the account view
+    /// </summary>
+    public bool ShowTagsList { get; set; }
+    /// <summary>
     /// Whether or not to sort transactions from first to last
     /// </summary>
     public bool SortFirstToLast { get; set; }
@@ -95,6 +99,7 @@ public class AccountMetadata : ICloneable
         CustomCurrencyDecimalDigits = null;
         DefaultTransactionType = TransactionType.Income;
         ShowGroupsList = true;
+        ShowTagsList = true;
         SortFirstToLast = false;
         SortTransactionsBy = SortBy.Date;
     }
@@ -150,6 +155,7 @@ public class AccountMetadata : ICloneable
             result.CustomCurrencyDecimalSeparator = readQueryMetadata.IsDBNull(10) ? null : (string.IsNullOrEmpty(readQueryMetadata.GetString(10)) ? null : readQueryMetadata.GetString(10));
             result.CustomCurrencyGroupSeparator = readQueryMetadata.IsDBNull(11) ? null : (string.IsNullOrEmpty(readQueryMetadata.GetString(11)) ? null : readQueryMetadata.GetString(11));
             result.CustomCurrencyDecimalDigits = readQueryMetadata.IsDBNull(12) ? null : readQueryMetadata.GetInt32(12);
+            result.ShowTagsList = readQueryMetadata.IsDBNull(13) ? true : readQueryMetadata.GetBoolean(13);
         }
         database.Close();
         return result;
@@ -171,6 +177,7 @@ public class AccountMetadata : ICloneable
             CustomCurrencyDecimalDigits = CustomCurrencyDecimalDigits,
             DefaultTransactionType = DefaultTransactionType,
             ShowGroupsList = ShowGroupsList,
+            ShowTagsList = ShowTagsList,
             SortFirstToLast = SortFirstToLast,
             SortTransactionsBy = SortTransactionsBy
         };

--- a/NickvisionMoney.Shared/Models/Configuration.cs
+++ b/NickvisionMoney.Shared/Models/Configuration.cs
@@ -1,8 +1,6 @@
 ﻿using Nickvision.Aura;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NickvisionMoney.Shared.Models;
@@ -77,6 +75,10 @@ public class Configuration : ConfigurationBase
     /// A folder to use to backup accounts as CSV
     /// </summary>
     public string CSVBackupFolder { get; set; }
+    /// <summary>
+    /// Whether or not to show graphs
+    /// </summary>
+    public bool ShowGraphs { get; set; }
 
     /// <summary>
     /// Constructs a Configuration
@@ -96,6 +98,7 @@ public class Configuration : ConfigurationBase
         UseNativeDigits = true;
         InsertSeparator = InsertSeparator.NumpadOnly;
         CSVBackupFolder = "";
+        ShowGraphs = true;
     }
 
     /// <summary>

--- a/NickvisionMoney.Shared/Models/Transaction.cs
+++ b/NickvisionMoney.Shared/Models/Transaction.cs
@@ -179,7 +179,7 @@ public class Transaction : ICloneable, IComparable<Transaction>, IDisposable, IE
             Receipt = Receipt?.Clone((x) => { }) ?? null,
             RepeatFrom = RepeatFrom,
             RepeatEndDate = RepeatEndDate,
-            Tags = Tags,
+            Tags = new List<string>(Tags),
             Notes = Notes
         };
     }

--- a/NickvisionMoney.Shared/Models/Transaction.cs
+++ b/NickvisionMoney.Shared/Models/Transaction.cs
@@ -1,6 +1,7 @@
 ﻿using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 using System;
+using System.Collections.Generic;
 
 namespace NickvisionMoney.Shared.Models;
 
@@ -81,6 +82,10 @@ public class Transaction : ICloneable, IComparable<Transaction>, IDisposable, IE
     /// </summary>
     public DateOnly? RepeatEndDate { get; set; }
     /// <summary>
+    /// A tags list for the Transaction
+    /// </summary>
+    public List<string> Tags { get; set; }
+    /// <summary>
     /// The notes for the transaction
     /// </summary>
     public string Notes { get; set; }
@@ -104,6 +109,7 @@ public class Transaction : ICloneable, IComparable<Transaction>, IDisposable, IE
         Receipt = null;
         RepeatFrom = -1;
         RepeatEndDate = null;
+        Tags = new List<string>();
         Notes = "";
     }
 
@@ -170,9 +176,10 @@ public class Transaction : ICloneable, IComparable<Transaction>, IDisposable, IE
             GroupId = GroupId,
             RGBA = RGBA,
             UseGroupColor = UseGroupColor,
-            Receipt = Receipt != null ? Receipt.Clone((x) => { }) : null,
+            Receipt = Receipt?.Clone((x) => { }) ?? null,
             RepeatFrom = RepeatFrom,
             RepeatEndDate = RepeatEndDate,
+            Tags = Tags,
             Notes = Notes
         };
     }
@@ -193,14 +200,11 @@ public class Transaction : ICloneable, IComparable<Transaction>, IDisposable, IE
         {
             return -1;
         }
-        else if (this == other)
+        if (this == other)
         {
             return 0;
         }
-        else
-        {
-            return 1;
-        }
+        return 1;
     }
 
     /// <summary>

--- a/NickvisionMoney.Shared/Resources/po/ar.po
+++ b/NickvisionMoney.Shared/Resources/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-07-01 02:14+0000\n"
 "Last-Translator: Ali Aljishi <ahj696@hotmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/nickvision-money/"
@@ -20,7 +20,7 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(انسخ)"
 
@@ -32,8 +32,20 @@ msgstr "(انسخ)"
 msgid "{0} from {1}"
 msgstr "{0} من {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -59,58 +71,58 @@ msgstr "اسم الحساب (مفتوح)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "إعدادات الحساب"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "نوع الحساب"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "أضف"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "أضف معاملةً جديدةً أو استورد معاملات من ملفٍّ."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "أأضيف كلمة سرٍّ لملفِّ البي‌دي‌إف؟"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "كلُّ الملفَّات"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "المقدار"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "المقدار (غير صالح)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "طبِّق"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -118,7 +130,7 @@ msgstr ""
 "أمتيقِّن من أنك تريد حذف هذه المجموعة؟\n"
 "هذا الإجراء نهائيٌّ."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -126,7 +138,7 @@ msgstr ""
 "أمتيقِّن من أنك تريد حذف هذه المعاملة؟\n"
 "هذا الإجراء نهائيٌّ."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -136,9 +148,9 @@ msgstr "أعمال"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "تعذَّر الوصول للمجلَّد المحدَّد. تأكَّد من أذونات فلاتباك."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "ألغِ"
 
@@ -147,13 +159,13 @@ msgstr "ألغِ"
 msgid "Change Password"
 msgstr "غيِّر كلمة السرِّ"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "جارٍ"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -161,7 +173,7 @@ msgstr ""
 "مساهمو جت‌هب ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "العملة"
@@ -199,16 +211,16 @@ msgstr "شعار العملة (فارغ)"
 msgid "Currency Symbol (Invalid)"
 msgstr "شعار العملة (غير صالح)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "التاريخ"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -231,41 +243,41 @@ msgstr "الفاصل العشري (فارغ)"
 msgid "Decimal Separator (Invalid)"
 msgstr "الفاصل العشري (غير صالح)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "احذف المعاملات الموجودة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "احذف المجموعة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "احذف المصدر فقط"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "احذف المصدر والمعاملات المولَّدة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "احذف المعاملة"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "دينار"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "الوصف"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "الوصف (فارغ)"
 
@@ -291,13 +303,13 @@ msgstr "كلمة سرِّ حساب الوجهة (غير صالح)"
 msgid "Destination Account Password (Required)"
 msgstr "كلمة سرِّ حساب الوجهة (مطلوب)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "افصل المعاملات الموجودة"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -306,50 +318,50 @@ msgstr "افصل المعاملات الموجودة"
 msgid "Expense"
 msgstr "نفقة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "صدِّر إلى ملفٍّ"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "صُدِّر الحساب للملفِّ بنجاح."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "وُلِّد: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "مستودع جت‌هب"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "مساء الخير!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "طاب يومك!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "مساء الخير!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "المجموعة"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "اسم المجموعة"
 
@@ -367,19 +379,19 @@ msgstr "فاصل المجموعة"
 msgid "Group Separator (Invalid)"
 msgstr "فاصل المجموعة (غير صالح)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "المجموعات"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "المساعدة"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "المعرِّف"
 
@@ -387,13 +399,13 @@ msgstr "المعرِّف"
 msgid "Import from Account"
 msgstr "استورد من حساب"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "استورد من ملفٍّ"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
@@ -404,9 +416,9 @@ msgstr[3] "اُستوردت من الملف {0} معاملات."
 msgstr[4] "اُستوردت من الملف {0} معاملة."
 msgstr[5] "اُستوردت من الملف {0} معاملة."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -415,24 +427,24 @@ msgstr[5] "اُستوردت من الملف {0} معاملة."
 msgid "Income"
 msgstr "دخل"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "احفظ مالك"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "محادثة ماتركس"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "غير متوفر"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -447,98 +459,98 @@ msgstr "الاسم (فارغ)"
 msgid "Name (Exists)"
 msgstr "الاسم (موجود)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "أبدًا"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "حساب نِكفِجِن دِنارو"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "لا"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "لا يوجد تاريخ انتهاء"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "لا توجد معاملات"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "لم يُعثر على معاملات"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "لا توجد معاملات حسب التصفية المحدَّدة."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "الملاحظات"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "افتح"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "افتح حسابًا"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "ملخَّص"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "الصفحة {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "كلمة سرِّ بي‌دي‌إف"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "اصبر ريثما تُستورد المعاملات..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "الإيصال"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "الإيصال (لا يمكن الوصول للملف)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "الإيصالات"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "تاريخ انتهاء التكرار"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "تاريخ انتهاء التكرار (غير صالح)"
 
@@ -547,11 +559,11 @@ msgstr "تاريخ انتهاء التكرار (غير صالح)"
 msgid "Repeat Interval"
 msgstr "مدَّة التكرار"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "غُيِّرت مدَّة التكرار"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -571,23 +583,29 @@ msgstr "حدِّد مجلَّد النسخ الاحتياطيِّ"
 msgid "Select Folder"
 msgstr "حدِّد مجلدًا"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "افرز حسب المقدار"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "افرز حسب التاريخ"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "افرز حسب المعرِّف"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "غُيِّرت كلمة سرِّ الحساب."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "أُزيلت كلمة سرِّ الحساب."
 
@@ -599,7 +617,7 @@ msgstr "سوف تزال كلمة السرِّ عقب إغلاق مربَّع ا�
 msgid "The passwords do not match."
 msgstr "لم تتطابق كلمتا السرِّ."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -611,15 +629,15 @@ msgstr ""
 "\n"
 "سوف تولَّد معاملات تكرار جديدة حسب المدَّة الجديدة."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "ليس في هذا الحساب مال ليحوِّله."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "هذا الحساب مفتوح بالفعل."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -633,7 +651,7 @@ msgstr ""
 "إن حذف معاملة المصدر فقط يتيح\n"
 "تعديل المعاملات المولَّدة."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -647,54 +665,54 @@ msgstr ""
 "إن تحديث معاملة المصدر فقط يفصل\n"
 "المعاملات المولَّدة عن المصدر."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "الإجماليُّ"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "المعاملة"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "المعاملات"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "المعاملات خارج المجموعات"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "حوِّل من {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "حوِّل إلى {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "علي الجشي <ahj696@hotmail.com>"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "النوع"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "تعذَّر تصدير الحساب للملفِّ."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -702,66 +720,72 @@ msgstr ""
 "تعذَّر استيراد المعلومات من الملف. تأكد من حصول التطبيق على صلاحية الوصول "
 "للملف وجرب مرةً أخرى."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr "تعذَّر استيراد المعلومات من الملف، فنوعه ليس مدعومًا."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "تعذَّر الدخول للحساب، فكلمة السرِّ المدخلة خاطئة."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 "تعذَّر فتح الحساب. تأكد من حصول التطبيق على صلاحية الوصول للملف وجرب مرةً أخرى."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "تتعذَّر الكتابة على حساب موجود."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "تتعذَّر الكتابة على حساب مفتوح."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "دون مجموعة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "حدِّث المصدر فقط"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "حدِّث المصدر والمعاملة المولَّدة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "حدِّث المعاملة"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "ارفع"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "اعرض"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -771,9 +795,9 @@ msgstr ""
 "\n"
 "إن فُقدت كلمة السرِّ فسوف يصبح الملفُّ غير قابل للفتح."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "نعم"
 
@@ -782,18 +806,18 @@ msgstr "نعم"
 msgid "Your system reported that your currency is"
 msgstr "يقول نظامك أن عملتك هي"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "صباح الخير!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "صباح الخير!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -935,65 +959,80 @@ msgstr "حدِّد كلَّ تصفيات المجموعات"
 msgid "Unselect Groups Filters"
 msgstr "ألغِ تحديد تصفيات المجموعات"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "بدِّل ظهور المجموعات"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "حدِّد كلَّ تصفيات المجموعات"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "ألغِ تحديد تصفيات المجموعات"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "التقويم"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "صفِّر لليوم"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "اليوم"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "اختر مدًى"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "البداية"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "النهاية"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "التالي"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "افرز من الأحدث إلى الأقدم"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "افرز من الأقدم إلى الأحدث"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "معاملة جديدة (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "جديد"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "اقتراحات"
 
@@ -1007,8 +1046,8 @@ msgid "Color"
 msgstr "اللون"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "احذف"
 
@@ -1315,20 +1354,24 @@ msgstr "استخدم لون المجموعة"
 msgid "Use unique color"
 msgstr "استخدم لونًا مميِّزًا"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "إضافات"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "أدر حقولًا إضافيةً في المعاملة."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "أدخل الملاحظات هنا"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "حرِّر المعاملة"
 

--- a/NickvisionMoney.Shared/Resources/po/cs.po
+++ b/NickvisionMoney.Shared/Resources/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: Fjuro <ifjuro@proton.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Kopírovat)"
 
@@ -31,8 +31,17 @@ msgstr "(Kopírovat)"
 msgid "{0} from {1}"
 msgstr "{0} z {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -55,58 +64,58 @@ msgstr "Název účtu (otevřený)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Nastavení účtu"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Typ účtu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Přidat"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Přidejte novou transakci nebo importujte transakce ze souboru."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Přidat heslo do PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Všechny soubory"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Množství"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Částka (neplatná)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Použít"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -114,7 +123,7 @@ msgstr ""
 "Opravdu chcete odstranit tuto skupinu?\n"
 "Tato akce je nevratná."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -122,7 +131,7 @@ msgstr ""
 "Opravdu chcete odstranit tuto transakci?\n"
 "Tato akce je nevratná."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +142,9 @@ msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 "Nelze získat přístup k vybrané složce, zkontrolujte oprávnění Flatpaku."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -144,18 +153,18 @@ msgstr "Zrušit"
 msgid "Change Password"
 msgstr "Změnit heslo"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Běžný"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr "Přispěvatelé na GitHubu ❤️"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Měna"
@@ -193,16 +202,16 @@ msgstr "Symbol měny (prázdný)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Symbol měny (neplatný)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Datum"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -225,41 +234,41 @@ msgstr "Oddělovač desetinných míst (prázdný)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Oddělovač desetinných míst (neplatný)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Odstranit stávající"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Odstranit skupinu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Odstranit pouze zdroj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Odstranit zdroj a generované"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Odstranit transakci"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Popis"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Popis (prázdný)"
 
@@ -285,13 +294,13 @@ msgstr "Heslo cílového účtu (neplatné)"
 msgid "Destination Account Password (Required)"
 msgstr "Heslo cílového účtu (povinné)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Odpojit stávající"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -300,50 +309,50 @@ msgstr "Odpojit stávající"
 msgid "Expense"
 msgstr "Výdaj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Export do souboru"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Účet byl úspěšně exportován do souboru."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Vygenerováno: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repozitář GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Dobré odpoledne!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Dobrý den!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Dobrý večer!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Skupina"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Název skupiny"
 
@@ -361,19 +370,19 @@ msgstr "Oddělovač skupin"
 msgid "Group Separator (Invalid)"
 msgstr "Oddělovač skupin (neplatný)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Skupiny"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "ID"
 
@@ -381,13 +390,13 @@ msgstr "ID"
 msgid "Import from Account"
 msgstr "Import z účtu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Import ze souboru"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
@@ -395,9 +404,9 @@ msgstr[0] "Importována {0} transakce ze souboru."
 msgstr[1] "Importovány {0} transakce ze souboru."
 msgstr[2] "Importováno {0} transakcí ze souboru."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -406,24 +415,24 @@ msgstr[2] "Importováno {0} transakcí ze souboru."
 msgid "Income"
 msgstr "Příjem"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Správa osobních financí"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -438,98 +447,98 @@ msgstr "Název (prázdný)"
 msgid "Name (Exists)"
 msgstr "Název (existuje)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nikdy"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Účet Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Ne"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Žádné datum ukončení"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Žádné transakce"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Nenalezeny žádné transakce"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Žádné transakce neodpovídají zadaným filtrům."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Poznámky"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Otevřít"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Otevřít účet"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Přehled"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Strana {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Heslo PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "Počkejte prosím na import transakcí..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Faktura"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Faktura (soubor nedostupný)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Účtenky"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Datum ukončení opakování"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Datum ukončení opakování (neplatné)"
 
@@ -538,11 +547,11 @@ msgstr "Datum ukončení opakování (neplatné)"
 msgid "Repeat Interval"
 msgstr "Interval opakování"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Interval opakování změněn"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -562,23 +571,29 @@ msgstr "Vyberte složku záloh"
 msgid "Select Folder"
 msgstr "Vybrat složku"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Seřadit podle množství"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Seřadit podle data"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Seřadit podle ID"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Heslo účtu bylo změněno."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Heslo účtu bylo odstraněno."
 
@@ -590,7 +605,7 @@ msgstr "Heslo bude odstraněno po zavření tohoto dialogu."
 msgid "The passwords do not match."
 msgstr "Hesla se neshodují."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -602,15 +617,15 @@ msgstr ""
 "\n"
 "Nové opakované transakce budou generovány na základě nového intervalu."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Tento účet nemá žádné peníze k převodu."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Tento účet je již otevřen."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -624,7 +639,7 @@ msgstr ""
 "Odstraněním pouze zdrojové transakce umožníte\n"
 "individuální úpravu vygenerovaných transakcí."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -638,54 +653,54 @@ msgstr ""
 "Aktualizací pouze zdrojové transakce dojde k odpojení\n"
 "vygenerovaných transakcí od zdroje."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr "Tobias Bernard"
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Celkem"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transakce"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transakce"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transakce bez skupiny"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Převést z {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Převést na {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Jonáš Loskot <jonas.loskot@pm.me>, 2023"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Typ"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Nepodařilo se exportovat účet do souboru."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -693,17 +708,17 @@ msgstr ""
 "Nepodařilo se importovat informace ze souboru. Ujistěte se, že má aplikace "
 "oprávnění k přístupu k vašemu souboru a zkuste to znovu."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 "Nepodařilo se importovat informace ze souboru. Nepodporovaný typ souboru."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Nelze se přihlásit k účtu. Zadané heslo je neplatné."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -711,50 +726,56 @@ msgstr ""
 "Nepodařilo se otevřít účet. Ujistěte se, že má aplikace oprávnění k přístupu "
 "k vašemu souboru a zkuste to znovu."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "Nelze přepsat existující účet."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "Nelze přepsat otevřený účet."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Neseskupené"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Aktualizovat pouze zdroj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Aktualizovat zdroj a generované"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Aktualizovat transakci"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Nahrát"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Zobrazit"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -764,9 +785,9 @@ msgstr ""
 "\n"
 "Pokud heslo ztratíte, soubor PDF bude nepřístupný."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Ano"
 
@@ -775,18 +796,18 @@ msgstr "Ano"
 msgid "Your system reported that your currency is"
 msgstr "Váš systém hlásí, že vaší měnou je"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Dobré ráno!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Dobré ráno!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -928,65 +949,80 @@ msgstr "Vybrat všechny filtry skupin"
 msgid "Unselect Groups Filters"
 msgstr "Zrušit výběr filtrů skupin"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Přepnout viditelnost skupin"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Vybrat všechny filtry skupin"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Zrušit výběr filtrů skupin"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalendář"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr "Vybrat aktuální měsíc"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Obnovit na dnešek"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Dnes"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Zvolte rozsah"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Začátek"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Konec"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr "Vizualizace"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Další"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Řazení od prvního do posledního"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Řazení od posledního k prvnímu"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nová transakce (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nová"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Návrhy"
 
@@ -1000,8 +1036,8 @@ msgid "Color"
 msgstr "Barva"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Odstranit"
 
@@ -1310,20 +1346,24 @@ msgstr "Použít barvu skupiny"
 msgid "Use unique color"
 msgstr "Použít unikátní barvu"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Další"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Spravovat další pole transakce."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Sem zadejte poznámky"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Upravit transakci"
 

--- a/NickvisionMoney.Shared/Resources/po/da.po
+++ b/NickvisionMoney.Shared/Resources/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Kopi)"
 
@@ -28,8 +28,16 @@ msgstr "(Kopi)"
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Ingen konto åbnet"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Konto indstillinger"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Kontotype"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Tilføj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Tilføj en ny overførsel eller importer overførsler fra en fil."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Alle filer"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Beløb"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Beløb (ugyldig)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Anvend"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Er du sikker på at du vil slette denne gruppe?\n"
 "Handlingen kan ikke fortrydes."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Er du sikker på at du vil slette overførslen?\n"
 "Handlingen kan ikke fortrydes."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -131,9 +139,9 @@ msgstr "Virksomhed"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Afbryd"
 
@@ -142,18 +150,18 @@ msgstr "Afbryd"
 msgid "Change Password"
 msgstr "Skift kodeord"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Indkomst"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Valuta"
@@ -192,16 +200,16 @@ msgstr "Valuta symbol (tom)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Valuta symbol (tom)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Dato"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -227,42 +235,42 @@ msgstr "Indsæt decimal-seperator"
 msgid "Decimal Separator (Invalid)"
 msgstr "Indsæt decimal-seperator"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Slet eksisterende"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Slet gruppe"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Slet kun udgangspunktet"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Slet udgangspunktet samt alle tilføjede"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Slet overførsel"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Beskrivelse (tom)"
 
@@ -288,13 +296,13 @@ msgstr "Kodeord på destinations konto (ugyldig)"
 msgid "Destination Account Password (Required)"
 msgstr "Kodeord på destinations konto (påkrævet)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Fjern eksisterende tilknytning"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -303,50 +311,50 @@ msgstr "Fjern eksisterende tilknytning"
 msgid "Expense"
 msgstr "Udgift"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Eksporter til fil"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Kontoen blev eksporteret til fil uden fejl."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Genereret: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub Depot"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "God eftermiddag!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "God dag!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Godaften!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Gruppenavn"
 
@@ -365,19 +373,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr "Beløb (ugyldig)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupper"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hjælp"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -386,22 +394,22 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "Importer fra fil"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importer fra fil"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, fuzzy, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Importerede {0} overførsel fra fil."
 msgstr[1] "Importerede {0} overførsel fra fil."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -410,24 +418,24 @@ msgstr[1] "Importerede {0} overførsel fra fil."
 msgid "Income"
 msgstr "Indkomst"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Administrer din privatøkonomi"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "I/T"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -442,99 +450,99 @@ msgstr "Navn (tom)"
 msgid "Name (Exists)"
 msgstr "Navn (findes allerede)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Aldrig"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro Konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Nej"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Ingen slutdato"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Ingen overførsler"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Ingen overførsler fundet"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Ingen overførsler ud fra de valgte filtre."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Åbn"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Åbn konto"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Oversigt"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Side {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 #, fuzzy
 msgid "PDF Password"
 msgstr "Kodeord"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Kvittering"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Kvitteringer"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Gentag slutdato"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Gentag sludato (ugyldig)"
 
@@ -543,11 +551,11 @@ msgstr "Gentag sludato (ugyldig)"
 msgid "Repeat Interval"
 msgstr "Gentag interval"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Intervallet for gentagelse er ændret"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -569,23 +577,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr "Vælg rækkevidde"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Sorter efter beløb"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Sorter efter dato"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Sorter efter Id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Kontoens kodeord blev ændret."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Kontoens kodeord blev fjernet."
 
@@ -598,7 +612,7 @@ msgstr "Kodeordet bliver fjernet når du lukker denne dialog."
 msgid "The passwords do not match."
 msgstr "Kontoens kodeord blev ændret."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -610,15 +624,15 @@ msgstr ""
 "\n"
 "Nye gentagende overførsler vil blive genereret ud fra det nye interval."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Denne konto har ingen penge tilgængelig til overførsel."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Denne konto er allerede åben."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -633,7 +647,7 @@ msgstr ""
 "Ved kun at slette udgangspunktet bliver det muligt at \n"
 "ændre i alle individuelt tilføjede overførsler."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -647,129 +661,135 @@ msgstr ""
 "Hvis du ændrer i den oprindelig overførsel, vil den \n"
 "fjerne tilknytningen til samtlige gentagelserne."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Overførsel"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Overførsler"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Overførsler uden en gruppe"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Overfør fra {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Overfør til {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Type"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Ude af stand til at eksportere konto til fil."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Ude af stand til at logge ind på kontoen. Kodeordet er forkert."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Ude af stand til at overskrive en åbnet konto."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Ude af stand til at overskrive en åbnet konto."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Ikke grupperet"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Kun opdatere kilden"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Opdater kilde og genereret"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Opdater overførsel"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Upload"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Visning"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Ja"
 
@@ -778,18 +798,18 @@ msgstr "Ja"
 msgid "Your system reported that your currency is"
 msgstr "Dit system fortalte at din valuta er"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Godmorgen!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Godmorgen!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -936,68 +956,83 @@ msgstr "Nulstil gruppe filtre"
 msgid "Unselect Groups Filters"
 msgstr "Nulstil gruppe filtre"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Skift gruppers synlighed"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Nulstil gruppe filtre"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Nulstil gruppe filtre"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalender"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Vælg rækkevidde"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Start"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "Slut"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Sorter fra første til sidste"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Sorter fra sidste til første"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Ny overførsel (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Ny"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1012,8 +1047,8 @@ msgid "Color"
 msgstr "Farve"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Slet"
 
@@ -1332,21 +1367,25 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 #, fuzzy
 msgid "Enter notes here"
 msgstr "Indtast navn her"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Ret overførsel"
 

--- a/NickvisionMoney.Shared/Resources/po/de.po
+++ b/NickvisionMoney.Shared/Resources/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-06-25 23:41+0000\n"
 "Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Kopie)"
 
@@ -31,8 +31,16 @@ msgstr "(Kopie)"
 msgid "{0} from {1}"
 msgstr "{0} von {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Kontoname (Eröffnet)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Konto-Einstellungen"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Kontotyp"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Füge eine neue Überweisung hinzu oder importiere eine von einer Datei."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Passwort zur PDF hinzufügen?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Alle dateien"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Betrag"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Betrag (Ungültig)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Möchtest du diese Gruppe wirklich löschen?\n"
 "Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Möchtest du diese Überweisung wirklich löschen?\n"
 "Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -132,9 +140,9 @@ msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 "Kann auf den ausgewählten Ordner nicht zugreifen, prüfe Flatpack-Rechte."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -143,13 +151,13 @@ msgstr "Abbrechen"
 msgid "Change Password"
 msgstr "Passwort ändern"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Girokonto"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -157,7 +165,7 @@ msgstr ""
 "Mitwirkende auf GitHub ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Währung"
@@ -195,16 +203,16 @@ msgstr "Währungszeichen (leer)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Währungszeichen (ungültig)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Datum"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -227,41 +235,41 @@ msgstr "Dezimaltrennzeichen (leer)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Dezimaltrennzeichen (ungültig)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Bestehende Löschen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Gruppe Löschen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Nur Ursprung Löschen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Ursprung und Generierte Löschen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Überweisung Löschen"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Beschreibung (Leer)"
 
@@ -287,13 +295,13 @@ msgstr "Passwort des Zielkontos (ungültig)"
 msgid "Destination Account Password (Required)"
 msgstr "Passwort für das Zielkonto (erforderlich)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Bestehende Trennen"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -302,50 +310,50 @@ msgstr "Bestehende Trennen"
 msgid "Expense"
 msgstr "Ausgaben"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Zu Datei exportieren"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Konto erfolgreich zu Datei exportiert."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Generiert: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub-Repo"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Guten Nachmittag!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Schönen Tag!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Guten Abend!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Gruppe"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Gruppenname"
 
@@ -363,19 +371,19 @@ msgstr "Gruppentrennzeichen"
 msgid "Group Separator (Invalid)"
 msgstr "Gruppentrennzeichen (ungültig)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Gruppen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "ID"
 
@@ -383,22 +391,22 @@ msgstr "ID"
 msgid "Import from Account"
 msgstr "Aus Konto importieren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Von Datei importieren"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "{0} Überweisung aus Datei importiert."
 msgstr[1] "{0} Überweisungen aus Datei importiert."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +415,24 @@ msgstr[1] "{0} Überweisungen aus Datei importiert."
 msgid "Income"
 msgstr "Einkommen"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Verwalte deine persönlichen Finanzen"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix-Chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "Entfällt"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +447,98 @@ msgstr "Name (Leer)"
 msgid "Name (Exists)"
 msgstr "Name (Existiert)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nie"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro-Konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Nein"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Kein End-Datum"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Keine Überweisungen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Keine Überweisungen Gefunden"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Keine Überweisung entsprechen den angegebenen Filtern."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Notizen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Öffnen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Konto öffnen"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Übersicht"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Seite {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "PDF-Passwort"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "Bitte warten Sie, während Transaktionen importiert werden..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Beleg"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Beleg (Datei unzugänglich)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Beleg"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Wiederholungs-Ende"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Wiederholungs-Ende (Ungültig)"
 
@@ -539,11 +547,11 @@ msgstr "Wiederholungs-Ende (Ungültig)"
 msgid "Repeat Interval"
 msgstr "Wiederholungs-Intervall"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Wiederholungs-Intervall Wurde Geändert"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -563,23 +571,29 @@ msgstr "Sicherungsordner auswählen"
 msgid "Select Folder"
 msgstr "Ordner auswählen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Nach Menge sortieren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Nach Datum sortieren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Nach ID sortieren"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Das Passwort des Kontos wurde geändert."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Das Passwort des Kontos wurde entfernt."
 
@@ -591,7 +605,7 @@ msgstr "Das Passwort wird nach dem Schließen dieses Dialogs entfernt werden."
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -604,15 +618,15 @@ msgstr ""
 "Neue wiederholte Überweisungen werden basierend auf dem neuen Intervall "
 "generiert."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Dieses Konto hat kein Geld zum überweisen mehr."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Dieses Konto ist schon geöffnet."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -627,7 +641,7 @@ msgstr ""
 "Nur die Ursprungs-Überweisung zu löschen macht es möglich&#xA;die "
 "generierten Überweisungen zu modifizieren."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -641,54 +655,54 @@ msgstr ""
 "Nur die Ursprungs-Überweisung zu aktualisieren wird die\n"
 "generierten Überweisungen unabhängig machen."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Insgesamt"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Überweisung"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Überweisungen"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Überweisungen ohne Gruppe"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Von {0} Überweisen"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Zu {0} Überweisen"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Jummit"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Art"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Konto konnte nicht zu Datei exportiert werden."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -697,19 +711,19 @@ msgstr ""
 "stellen Sie sicher, dass die App die Berechtigungen für den Zugriff auf die "
 "Datei hat und versuchen Sie es erneut."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 "Die Informationen aus der Datei können nicht importiert werden. Nicht "
 "unterstützter Dateityp."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 "Anmeldung zum Konto nicht möglich. Das angegebene Kennwort ist ungültig."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -718,50 +732,56 @@ msgstr ""
 "die Berechtigungen für den Zugriff auf die Datei hat und versuchen Sie es "
 "erneut."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "Bestehendes Konto konnte nicht überschrieben werden."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "Eröffnetes Konto konnte nicht überschrieben werden."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Ungruppiert"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Nur Ursprung Aktualisieren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Ursprung und Generierte Aktualisieren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Überweisung Aktualisieren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Hochladen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Ansehen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -771,9 +791,9 @@ msgstr ""
 "\n"
 "Wenn das Passwort verloren geht, ist die PDF-Datei unzugänglich."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Ja"
 
@@ -782,18 +802,18 @@ msgstr "Ja"
 msgid "Your system reported that your currency is"
 msgstr "Dein System meldete deine Währung sei"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Guten Morgen!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Guten Morgen!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -939,65 +959,80 @@ msgstr "Alle Gruppenfilter auswählen"
 msgid "Unselect Groups Filters"
 msgstr "Gruppenfilter abwählen"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Gruppen-Sichtbarkeit Umschalten"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Alle Gruppenfilter auswählen"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Gruppenfilter abwählen"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalender"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Für heute zurücksetzen"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Heute"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Wähle Zeitspanne Aus"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Beginn"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Ende"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Weiter"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Sortiere Vom Ersten Zum Letzten"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Sortiere Vom Letzten Zum Ersten"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Neue Überweisung (Strg+Umschalt+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Neu"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Vorschläge"
 
@@ -1011,8 +1046,8 @@ msgid "Color"
 msgstr "Farbe"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Löschen"
 
@@ -1327,20 +1362,24 @@ msgstr "Gruppenfarbe verwenden"
 msgid "Use unique color"
 msgstr "Einzigartige Farbe verwenden"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extras"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Verwalte Extra-Felder der Transaktion."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Notizen hier eingeben"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Überweisung Editieren"
 

--- a/NickvisionMoney.Shared/Resources/po/denaro.pot
+++ b/NickvisionMoney.Shared/Resources/po/denaro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr ""
 
@@ -30,8 +30,16 @@ msgstr ""
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -53,70 +61,70 @@ msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr ""
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -126,9 +134,9 @@ msgstr ""
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr ""
 
@@ -137,18 +145,18 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr ""
@@ -186,16 +194,16 @@ msgstr ""
 msgid "Currency Symbol (Invalid)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -218,41 +226,41 @@ msgstr ""
 msgid "Decimal Separator (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr ""
 
@@ -278,13 +286,13 @@ msgstr ""
 msgid "Destination Account Password (Required)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -293,50 +301,50 @@ msgstr ""
 msgid "Expense"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr ""
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr ""
 
@@ -354,19 +362,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr ""
 
@@ -374,22 +382,22 @@ msgstr ""
 msgid "Import from Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -398,24 +406,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -430,98 +438,98 @@ msgstr ""
 msgid "Name (Exists)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr ""
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr ""
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr ""
 
@@ -530,11 +538,11 @@ msgstr ""
 msgid "Repeat Interval"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr ""
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -554,23 +562,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr ""
 
@@ -582,7 +596,7 @@ msgstr ""
 msgid "The passwords do not match."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -590,15 +604,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -607,7 +621,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -616,127 +630,133 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr ""
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr ""
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr ""
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr ""
 
@@ -745,18 +765,18 @@ msgstr ""
 msgid "Your system reported that your currency is"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -898,65 +918,77 @@ msgstr ""
 msgid "Unselect Groups Filters"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+msgid "Select All Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+msgid "Unselect Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -970,8 +1002,8 @@ msgid "Color"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr ""
 
@@ -1272,20 +1304,24 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr ""
 

--- a/NickvisionMoney.Shared/Resources/po/es.po
+++ b/NickvisionMoney.Shared/Resources/po/es.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-08-09 12:21+0000\n"
-"Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted.weblate"
-".org>\n"
+"Last-Translator: Óscar Fernández Díaz <oscfdezdz@users.noreply.hosted."
+"weblate.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/nickvision-money/"
 "app/es/>\n"
 "Language: es\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copia)"
 
@@ -32,8 +32,16 @@ msgstr "(Copia)"
 msgid "{0} from {1}"
 msgstr "{0} de {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -55,59 +63,59 @@ msgstr "Nombre de la cuenta (abierta)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Configuración de la cuenta"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Tipo de cuenta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Añadir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 "Añadir una transacción nueva o importar transacciones desde un archivo."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "¿Añadir contraseña a un PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Todos los archivos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Importe"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Importe (no válido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +123,7 @@ msgstr ""
 "¿Está seguro de que desea borrar este grupo?\n"
 "Esta acción es irreversible."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +131,7 @@ msgstr ""
 "¿Está seguro de que desea borrar esta transacción?\n"
 "Esta acción es irreversible."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -135,9 +143,9 @@ msgstr ""
 "No se puede acceder a la carpeta seleccionada, compruebe los permisos de "
 "Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -146,18 +154,18 @@ msgstr "Cancelar"
 msgid "Change Password"
 msgstr "Cambiar contraseña"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Corriente"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr "Contribuidores on GitHub ❤️"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Moneda"
@@ -195,16 +203,16 @@ msgstr "Símbolo de moneda (vacío)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Símbolo de la moneda (no válido)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Fecha"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -227,41 +235,41 @@ msgstr "Separador de decimal (vacío)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Separador de decimal (No válido )"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Borrar existente"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Borrar grupo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Borrar solo origen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Borrar origen y generadas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Borrar transacción"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Descripción"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Descripción (vacía)"
 
@@ -287,13 +295,13 @@ msgstr "Contraseña de la cuenta de destino (no válida)"
 msgid "Destination Account Password (Required)"
 msgstr "Contraseña de la cuenta de destino (requerida)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Disociar existente"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -302,50 +310,50 @@ msgstr "Disociar existente"
 msgid "Expense"
 msgstr "Gastos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exportar a archivo"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Cuenta exportada a archivo correctamente."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Generado: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repositorio de GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "¡Buenas tardes!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "¡Buen día!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "¡Buenas noches!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grupo"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nombre del grupo"
 
@@ -363,19 +371,19 @@ msgstr "Separador de grupos"
 msgid "Group Separator (Invalid)"
 msgstr "Separador de grupos (no válido)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ayuda"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -383,22 +391,22 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "Importar desde cuenta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importar desde archivo"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Importada {0} transacción del archivo."
 msgstr[1] "Importadas {0} transacciones del archivo."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +415,24 @@ msgstr[1] "Importadas {0} transacciones del archivo."
 msgid "Income"
 msgstr "Ingresos"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Administre sus finanzas personales"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Chat de Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/D"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +447,98 @@ msgstr "Nombre (vacío)"
 msgid "Name (Exists)"
 msgstr "Nombre (existente)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nunca"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Cuenta Denaro de Nickvision"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "No"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Sin fecha final"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Sin transacciones"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "No se han encontrado transacciones"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Ninguna transacción coincide con los filtros especificados."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Notas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Abrir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Abrir cuenta"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Resumen"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Página {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Contraseña del PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "Espere mientras se importan las transacciones..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Recibo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Recibo (Archivo inaccesible)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Recibos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Repetir fecha final"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Repetir fecha final (no válida)"
 
@@ -539,11 +547,11 @@ msgstr "Repetir fecha final (no válida)"
 msgid "Repeat Interval"
 msgstr "Intervalo de repetición"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Intervalo de repetición modificado"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -563,23 +571,29 @@ msgstr "Seleccione la carpeta de copia de seguridad"
 msgid "Select Folder"
 msgstr "Seleccionar carpeta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Ordenar por cantidad"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Ordenar por fecha"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Ordenar por id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "La contraseña de la cuenta ha sido cambiada."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "La contraseña de la cuenta ha sido eliminada."
 
@@ -591,7 +605,7 @@ msgstr "La contraseña se eliminará al cerrar este diálogo."
 msgid "The passwords do not match."
 msgstr "Las contraseñas no concuerdan."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -604,15 +618,15 @@ msgstr ""
 "Se generarán nuevas transacciones de repetición basadas en el nuevo "
 "intervalo."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Esta cuenta no tiene dinero disponible para transferir."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Esta cuenta ya está abierta."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -626,7 +640,7 @@ msgstr ""
 "Borrando sólo la transacción de origen permitirá que las\n"
 "transacciones generadas sean modificables."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -640,54 +654,54 @@ msgstr ""
 "Al actualizar sólo la transacción de origen se disociarán\n"
 "las transacciones generadas en origen."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr "Tobias Bernard"
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transacción"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transacciones"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transacciones sin grupo"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transferir desde {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transferir a {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Óscar Fernández Díaz <oscfdezdz@tuta.io>"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "No se puede exportar la cuenta a un archivo."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -695,19 +709,19 @@ msgstr ""
 "No se ha podido importar la información del archivo. Asegúrese de que la "
 "aplicación tiene permisos para acceder al archivo e inténtelo de nuevo."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 "No se ha podido importar información del fichero. Tipo de archivo no "
 "compatible."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 "No se puede acceder a la cuenta. La contraseña proporcionada no es válida."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -715,50 +729,56 @@ msgstr ""
 "No se ha podido abrir la cuenta. Asegúrese de que la aplicación tiene los "
 "permisos para acceder al archivo e inténtelo de nuevo."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "No se puede sobrescribir una cuenta existente."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "No se puede sobrescribir una cuenta abierta."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Sin agrupar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Actualizar solo origen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Actualizar origen y generadas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Actualizar transacción"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Cargar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Ver"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -768,9 +788,9 @@ msgstr ""
 "\n"
 "Si pierde la contraseña, el PDF será inaccesible."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Sí"
 
@@ -779,18 +799,18 @@ msgstr "Sí"
 msgid "Your system reported that your currency is"
 msgstr "Su sistema informó de que su moneda es"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "¡Buenos días!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "¡Buenos días!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -932,65 +952,80 @@ msgstr "Seleccionar todos los grupos de Filtros"
 msgid "Unselect Groups Filters"
 msgstr "Desmarcar los filtros de los grupos"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Conmutar visibilidad de grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Seleccionar todos los grupos de Filtros"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Desmarcar los filtros de los grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Calendario"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr "Seleccionar mes actual"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Volver al día de hoy"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Hoy"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Seleccionar intervalo"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Inicio"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Fin"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr "Visualizar"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Siguiente"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Ordenar del primero al último"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Ordenar del último al primero"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Transacción nueva (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nueva"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Sugerencias"
 
@@ -1004,8 +1039,8 @@ msgid "Color"
 msgstr "Color"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Borrar"
 
@@ -1319,20 +1354,24 @@ msgstr "Usar color de grupo"
 msgid "Use unique color"
 msgstr "Usar color único"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extras"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Gestionar los campos adicionales de la transacción."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Escriba aquí las notas"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Editar transacción"
 

--- a/NickvisionMoney.Shared/Resources/po/et.po
+++ b/NickvisionMoney.Shared/Resources/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr ""
 
@@ -28,8 +28,16 @@ msgstr ""
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,73 +62,73 @@ msgstr "Konto"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 #, fuzzy
 msgid "Account Settings"
 msgstr "Sätted"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 #, fuzzy
 msgid "Account Type"
 msgstr "Konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Lisa"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Kõik failid"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 #, fuzzy
 msgid "Amount"
 msgstr "Konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Rakenda"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -130,9 +138,9 @@ msgstr ""
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Tühista"
 
@@ -141,18 +149,18 @@ msgstr "Tühista"
 msgid "Change Password"
 msgstr ""
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr ""
@@ -190,16 +198,16 @@ msgstr ""
 msgid "Currency Symbol (Invalid)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -222,43 +230,43 @@ msgstr ""
 msgid "Decimal Separator (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Kustuta tehing"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 #, fuzzy
 msgid "Delete Group"
 msgstr "Kustuta tehing"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Kustuta tehing"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr ""
 
@@ -285,13 +293,13 @@ msgstr ""
 msgid "Destination Account Password (Required)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -300,50 +308,50 @@ msgstr ""
 msgid "Expense"
 msgstr "Kulu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Tere päevast!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Tere päevast!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Tere õhtust!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr ""
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr ""
 
@@ -361,19 +369,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Abi"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr ""
 
@@ -381,22 +389,22 @@ msgstr ""
 msgid "Import from Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -405,24 +413,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr "Tulu"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrixi jututuba"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -437,100 +445,100 @@ msgstr ""
 msgid "Name (Exists)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Ei"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Pole tehinguid"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 #, fuzzy
 msgid "No Transactions Found"
 msgstr "Pole tehinguid"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Ava"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 #, fuzzy
 msgid "Open Account"
 msgstr "Uus konto"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Ülevaade"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr ""
 
@@ -539,11 +547,11 @@ msgstr ""
 msgid "Repeat Interval"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr ""
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 #, fuzzy
@@ -565,23 +573,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr ""
 
@@ -593,7 +607,7 @@ msgstr ""
 msgid "The passwords do not match."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -601,15 +615,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -618,7 +632,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -627,130 +641,136 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Kokku"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 #, fuzzy
 msgid "Transaction"
 msgstr "Tehingud"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Tehingud"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 #, fuzzy
 msgid "Transactions without a group"
 msgstr "Tehingud"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, fuzzy, csharp-format
 msgid "Transfer To {0}"
 msgstr "Tehing ({0})"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr ""
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 #, fuzzy
 msgid "Update Transaction"
 msgstr "Kustuta tehing"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Jah"
 
@@ -759,18 +779,18 @@ msgstr "Jah"
 msgid "Your system reported that your currency is"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Tere hommikust!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Head ööd!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -916,67 +936,79 @@ msgstr ""
 msgid "Unselect Groups Filters"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+msgid "Select All Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+msgid "Unselect Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalender"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 #, fuzzy
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Uus konto (Ctrl+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Uus"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -991,8 +1023,8 @@ msgid "Color"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr ""
 
@@ -1300,20 +1332,24 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 #, fuzzy
 msgid "Edit Transaction"
 msgstr "Tehingud"

--- a/NickvisionMoney.Shared/Resources/po/fi.po
+++ b/NickvisionMoney.Shared/Resources/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-08-06 14:49+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Kopio)"
 
@@ -31,8 +31,16 @@ msgstr "(Kopio)"
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Tilin nimi (avattu)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Tilin asetukset"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Tilin tyyppi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Lisää"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Lisää uusi tapahtuma tai tuo tapahtumat tiedostosta."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Lisätäänkö salasana PDF:ään?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Kaikki tiedostot"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Määrä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Määrä (virheellinen)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Toteuta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Haluatko varmasti poistaa tämän ryhmän?\n"
 "Tätä toimintoa ei voi perua."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Haluatko varmasti poistaa tämän tapahtuman?\n"
 "Tätä toimintoa ei voi perua."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -131,9 +139,9 @@ msgstr "Yritys"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Ei pääsyä valittuun kansioon, tarkista Flatpak-oikeudet."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Peru"
 
@@ -142,13 +150,13 @@ msgstr "Peru"
 msgid "Change Password"
 msgstr "Vaihda salasana"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Siirto"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -156,7 +164,7 @@ msgstr ""
 "Avustajat GitHubissa ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Valuutta"
@@ -194,16 +202,16 @@ msgstr "Valuutan symboli (tyhjä)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Valuutan symboli (virheellinen)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Päivä"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -226,42 +234,42 @@ msgstr "Desimaalierotin (tyhjä)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Desimaalierotin (virheellinen)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Poista olemassa oleva"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Poista ryhmä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 #, fuzzy
 msgid "Delete Only Source"
 msgstr "Poista ryhmä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Poista tapahtuma"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Kuvaus"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Kuvaus (tyhjä)"
 
@@ -287,13 +295,13 @@ msgstr "Kohdetilin salasana (virheellinen)"
 msgid "Destination Account Password (Required)"
 msgstr "Kohdetilin salasana (pakollinen)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -302,50 +310,50 @@ msgstr ""
 msgid "Expense"
 msgstr "Meno"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Vie tiedostoon"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Tili viety tiedostoon onnistuneesti."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Luotu: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub-tietovarasto"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Hyvää iltapäivää!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Hyvää päivää!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Hyvää iltaa!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Ryhmä"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Ryhmän nimi"
 
@@ -363,19 +371,19 @@ msgstr "Ryhmäerotin"
 msgid "Group Separator (Invalid)"
 msgstr "Ryhmäerotin (virheellinen)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Ryhmät"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ohje"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Tunniste"
 
@@ -383,22 +391,22 @@ msgstr "Tunniste"
 msgid "Import from Account"
 msgstr "Tuo tililtä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Tuo tiedostosta"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Tuotu {0} tapahtuma tiedostosta."
 msgstr[1] "Tuotu {0} tapahtumaa tiedostosta."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +415,24 @@ msgstr[1] "Tuotu {0} tapahtumaa tiedostosta."
 msgid "Income"
 msgstr "Tulo"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Hallitse raha-asioitasi"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix-keskustelu"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "-"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +447,98 @@ msgstr "Nimi (tyhjä)"
 msgid "Name (Exists)"
 msgstr "Nimi (olemassa)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Ei koskaan"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro -tili"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Ei"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Ei loppupäivää"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Ei tapahtumia"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Tapahtumia ei löytynyt"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Suodattimia vastaavia tapahtumia ei löydy."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Avaa"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Avaa tili"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Yleisnäkymä"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Sivu {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "PDF-salasana"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Kuitti"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Kuitit"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Toistumisen loppupäivä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Toistumisen loppupäivä (virheellinen)"
 
@@ -539,12 +547,12 @@ msgstr "Toistumisen loppupäivä (virheellinen)"
 msgid "Repeat Interval"
 msgstr "Toistumisväli"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 #, fuzzy
 msgid "Repeat Interval Changed"
 msgstr "Toistumisväli"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -564,23 +572,29 @@ msgstr "Valitse varmuuskopiokansio"
 msgid "Select Folder"
 msgstr "Valitse kansio"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Järjestä summan mukaan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Järjestä päivän mukaan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Järjestä tunnisteen mukaan"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Tilin salasana vaihdettiin."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Tilin salasana poistettiin."
 
@@ -592,7 +606,7 @@ msgstr "Salasana poistetaan, kun tämä ikkuna suljetaan."
 msgid "The passwords do not match."
 msgstr "Salasanat eivät täsmää."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -600,15 +614,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Tällä tilillä ei ole riittävästi rahaa siirtoa varten."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Tämä tili on jo avattu."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -617,7 +631,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -626,119 +640,125 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Yhteensä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Tapahtuma"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Tapahtumat"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Tapahtumat ilman ryhmää"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Siirrä kohteesta {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Siirrä kohteeseen {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Jiri Grönroos"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tyyppi"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Tiliä ei voitu viedä tiedostoon."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Kirjautuminen tilille ei onnistu. Annettu salasana on virheellinen."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "Olemassa olevan tilin korvaaminen ei onnistu."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Tiliä ei voitu viedä tiedostoon."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Ryhmittämätön"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Päivitä vain lähde"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Päivitä tapahtuma"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Lähetä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Näytä"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -748,9 +768,9 @@ msgstr ""
 "\n"
 "Jos salasana katoaa, PDF-tiedosto ei ole käytettävissä."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -759,18 +779,18 @@ msgstr "Kyllä"
 msgid "Your system reported that your currency is"
 msgstr "Järjestelmä ilmoitti, että käyttämäsi valuutta on"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Hyvää huomenta!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Hyvää huomenta!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -917,65 +937,80 @@ msgstr "Nollaa ryhmäsuodattimet"
 msgid "Unselect Groups Filters"
 msgstr "Nollaa ryhmäsuodattimet"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Näytä/piilota ryhmät"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Nollaa ryhmäsuodattimet"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Nollaa ryhmäsuodattimet"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalenteri"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr "Valitse nykyinen kuukausi"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Tänään"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Valitse aikaväli"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Alku"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Loppu"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Seuraava"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Järjestä ensimmäisestä viimeiseen"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Järjestä viimeisestä ensimmäiseen"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Uusi tapahtuma (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Uusi"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Ehdotukset"
 
@@ -989,8 +1024,8 @@ msgid "Color"
 msgstr "Väri"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Poista"
 
@@ -1294,21 +1329,25 @@ msgstr "Käytä ryhmän väriä"
 msgid "Use unique color"
 msgstr "Käytä yksilöllistä väriä"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 #, fuzzy
 msgid "Enter notes here"
 msgstr "Kirjoita nimi tähän"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Muokkaa tapahtumaa"
 

--- a/NickvisionMoney.Shared/Resources/po/fr.po
+++ b/NickvisionMoney.Shared/Resources/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-08-09 12:21+0000\n"
 "Last-Translator: rene-coty <irenee.thirion@e.email>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copie)"
 
@@ -31,8 +31,16 @@ msgstr "(Copie)"
 msgid "{0} from {1}"
 msgstr "{0} de {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,60 +62,60 @@ msgstr "Nom du compte (ouvert)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Paramètres du compte"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Type de compte"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Add"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 "Ajoutez une nouvelle transaction ou importez des transactions depuis un "
 "fichier."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Ajouter un mot de passe au document PDF ?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Montant"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Montant (invalide)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +123,7 @@ msgstr ""
 "Êtes-vous sûr de vouloir supprimer ce groupe ?\n"
 "Cette action est irréversible."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +131,7 @@ msgstr ""
 "Êtes-vous sûr·e de vouloir supprimer cette transaction ?\n"
 "Cette action est irréversible."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -135,9 +143,9 @@ msgstr ""
 "Impossible d’accéder au dossier sélectionné, vérifiez les permissions "
 "Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -146,18 +154,18 @@ msgstr "Annuler"
 msgid "Change Password"
 msgstr "Changer le mot de passe"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Chèques"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr "Contributeurs sur GitHub ❤️"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Devise monétaire"
@@ -195,16 +203,16 @@ msgstr "Symbole monétaire (vide)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Symbole monétaire (invalide)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Date"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -227,41 +235,41 @@ msgstr "Séparateur de décimales (vide)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Séparateur de décimales (invalide)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Supprimer l’existant"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Supprimer le groupe"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Supprimer uniquement la source"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Supprimer la source et les transactions générées"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Supprimer la transaction"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Description"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Description (vide)"
 
@@ -287,13 +295,13 @@ msgstr "Mot de passe du compte de destination (invalide)"
 msgid "Destination Account Password (Required)"
 msgstr "Mot de passe du compte de destination (obligatoire)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Dissocier l'existant"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -302,50 +310,50 @@ msgstr "Dissocier l'existant"
 msgid "Expense"
 msgstr "Dépenses"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exporter vers un fichier"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Compte exporté dans le fichier avec succès."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Généré : {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Dépôt GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Bonjour !"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Bonjour !"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Bonsoir !"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Groupe"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nom de groupe"
 
@@ -363,19 +371,19 @@ msgstr "Séparateur de groupes"
 msgid "Group Separator (Invalid)"
 msgstr "Séparateur de groupes (invalide)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Groupes"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aide"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Identifiant"
 
@@ -383,22 +391,22 @@ msgstr "Identifiant"
 msgid "Import from Account"
 msgstr "Importer à partir d’un compte"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importer à partir d’un fichier"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "{0} transaction importée depuis le fichier."
 msgstr[1] "{0} transactions importées depuis le fichier."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +415,24 @@ msgstr[1] "{0} transactions importées depuis le fichier."
 msgid "Income"
 msgstr "Revenus"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Gérez vos finances personnelles"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Discussion Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "Indispo."
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +447,98 @@ msgstr "Nom (vide)"
 msgid "Name (Exists)"
 msgstr "Nom (existe)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Jamais"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Compte Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Non"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Pas de date de fin"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Aucune transaction"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Aucune transaction trouvée"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Aucune transaction ne correspond aux critères spécifiés."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Notes"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Ouvrir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Ouvrir un compte"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Aperçu"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Page {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Mot de passe PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "Veuillez patienter pendant l’importation des transactions…"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Reçu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Reçu (fichier inaccessible)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Reçus"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Date de fin de répétition"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Date de fin de répétition (invalide)"
 
@@ -539,11 +547,11 @@ msgstr "Date de fin de répétition (invalide)"
 msgid "Repeat Interval"
 msgstr "Intervalle de répétition"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Intervalle de répétition modifié"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -563,23 +571,29 @@ msgstr "Sélectionner un dossier de sauvegarde"
 msgid "Select Folder"
 msgstr "Sélectionner un dossier"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Trier par montant"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Trier par date"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Trier par identifiant"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Le mot de passe du compte a été modifié."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Le mot de passe du compte a été retiré."
 
@@ -591,7 +605,7 @@ msgstr "Le mot de passe sera retiré à la fermeture de cette boîte de dialogue
 msgid "The passwords do not match."
 msgstr "Les mots de passe ne correspondent pas."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -604,15 +618,15 @@ msgstr ""
 "Les nouvelles transactions répétées seront générées sur la base du nouvel "
 "intervalle."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Ce compte n’a pas d’argent disponible à transférer."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Ce compte est déjà ouvert."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -626,7 +640,7 @@ msgstr ""
 "En supprimant uniquement la transaction source, les transactions\n"
 "individuelles générées deviendront modifiables."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -640,54 +654,54 @@ msgstr ""
 "En mettant à jour uniquement la transaction source,\n"
 "les transactions générées en seront dissociées."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr "Tobias Bernard"
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transaction"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transactions"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transactions sans groupe"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transférer depuis {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transférer vers {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Irénée Thirion"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Type"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Impossible d’exporter le compte dans un fichier."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -695,20 +709,20 @@ msgstr ""
 "Impossible d’importer les informations depuis le fichier. Assurez vous que "
 "l’application a les permissions d’accès au fichier, et réessayez."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 "Impossible d’importer les informations depuis le fichier. Type de fichier "
 "non pris en charge."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 "Impossible de se connecter au compte. Le mot de passe fourni n'est pas "
 "valide."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -716,50 +730,56 @@ msgstr ""
 "Impossible d’ouvrir le compte. Assurez-vous que l’application dispose des "
 "permissions d’accès au fichier, et réessayez."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "Impossible de remplacer un compte existant."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "Impossible de remplacer un compte ouvert."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Sans groupe"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Mettre à jour la source uniquement"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Mettre à jour la source et les transactions générées"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Mettre à jour la transaction"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Téléverser"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Voir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -769,9 +789,9 @@ msgstr ""
 "\n"
 "En cas de perte du mot de passe le document sera inaccessible."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Oui"
 
@@ -780,18 +800,18 @@ msgstr "Oui"
 msgid "Your system reported that your currency is"
 msgstr "Votre système indique que votre devise monétaire est"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Bonjour !"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Bonjour !"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -934,65 +954,80 @@ msgstr "Sélectionner tous les filtres de groupes"
 msgid "Unselect Groups Filters"
 msgstr "Désélectionner les filtres de groupes"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Basculer la visibilité des groupes"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Sélectionner tous les filtres de groupes"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Désélectionner les filtres de groupes"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Calendrier"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr "Sélectionner le mois actuel"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Réinitialiser à aujourd’hui"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Aujourd’hui"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Choisir l’intervalle"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Début"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Fin"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr "Visualiser"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Suivant"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Trier du premier au dernier"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Trier du dernier au premier"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nouvelle transaction (Ctrl+Maj+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nouveau"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Suggestions"
 
@@ -1006,8 +1041,8 @@ msgid "Color"
 msgstr "Couleur"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1323,20 +1358,24 @@ msgstr "Utiliser une couleur de groupe"
 msgid "Use unique color"
 msgstr "Utiliser une couleur unique"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extras"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Champs supplémentaires de la transaction."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Entrez vos notes ici"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Modifier la transaction"
 

--- a/NickvisionMoney.Shared/Resources/po/hi.po
+++ b/NickvisionMoney.Shared/Resources/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copy)"
 
@@ -28,8 +28,16 @@ msgstr "(Copy)"
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Account Type"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Account Settings"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Account Type"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Add"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "धनराशि"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "धनराशि (अवैध)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Apply"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "क्या आप वाकई इस समूह को हटाना चाहते हैं?\n"
 "यह क्रिया अपरिवर्तनीय है।"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "क्या आप वाकई इस लेनदेन को हटाना चाहते हैं?\n"
 "यह क्रिया अपरिवर्तनीय है।"
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -131,9 +139,9 @@ msgstr "Business"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "रद्द (Cancel)"
 
@@ -142,18 +150,18 @@ msgstr "रद्द (Cancel)"
 msgid "Change Password"
 msgstr "Change Password"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Checking"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Currency"
@@ -192,16 +200,16 @@ msgstr "Currency Symbol (Empty)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Currency Symbol (Empty)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "तिथि"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -227,42 +235,42 @@ msgstr "Insert Decimal Separator"
 msgid "Decimal Separator (Invalid)"
 msgstr "Insert Decimal Separator"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Delete Existing"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "समूह हटाएँ"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Delete Only Source"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Delete Source and Generated"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "लेन-देन हटाएँ"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "विवरण"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "विवरण (खाली)"
 
@@ -290,13 +298,13 @@ msgstr "Destination Account Password (Invalid)"
 msgid "Destination Account Password (Required)"
 msgstr "Destination Account Password (Required)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Disassociate Existing"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -305,51 +313,51 @@ msgstr "Disassociate Existing"
 msgid "Expense"
 msgstr "लागत/खर्च"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 #, fuzzy
 msgid "Export to File"
 msgstr "CSV से आयात करें"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Generated: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "नमस्ते!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "नमस्ते!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "नमस्ते!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "समूह"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Group Name"
 
@@ -368,19 +376,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr "धनराशि (अवैध)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "समूह"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Help"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -389,22 +397,22 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "CSV से आयात करें"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "CSV से आयात करें"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -413,24 +421,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr "आय/कमाई"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "एक व्यक्तिगत वित्त संयोजक"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -445,100 +453,100 @@ msgstr "नाम (खाली)"
 msgid "Name (Exists)"
 msgstr "नाम (पहले से मौजूद है)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "कभी नहीं"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "नहीं"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "No End Date"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "कोई लेनदेन मौजूद नहीं"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "कोई लेनदेन मौजूद नहीं"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "कोई लेनदेन दिए गए फ़िल्टर से मेल नहीं खाता।"
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "खाता खोलें"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "अवलोकन"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Page {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 #, fuzzy
 msgid "PDF Password"
 msgstr "Password"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 #, fuzzy
 msgid "Receipt"
 msgstr "Receipts"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Receipts"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Repeat End Date"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Repeat End Date (Invalid)"
 
@@ -547,11 +555,11 @@ msgstr "Repeat End Date (Invalid)"
 msgid "Repeat Interval"
 msgstr "दोहराई का समय अंतराल"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Repeat Interval Changed"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -573,23 +581,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr "दायरे का चयन करें"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Sort By Amount"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Sort By Date"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Sort By Id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "The password of the account was changed."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "The password of the account was removed."
 
@@ -602,7 +616,7 @@ msgstr "The password will be removed upon closing this dialog."
 msgid "The passwords do not match."
 msgstr "The password of the account was changed."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -614,15 +628,15 @@ msgstr ""
 "\n"
 "New repeat transactions will be generated based off the new interval."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "इस खाते में ट्रांसफ़र करने के लिए कोई धनराशि उपलब्ध नहीं है।"
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -637,7 +651,7 @@ msgstr ""
 "Deleting only the source transaction will allow individual\n"
 "generated transactions to be modifiable."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -651,131 +665,137 @@ msgstr ""
 "Updating only the source transaction will disassociate\n"
 "generated transactions from the source."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "टोटल (कुल)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "लेनदेन"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "लेनदेन"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 #, fuzzy
 msgid "Transactions without a group"
 msgstr "कोई लेनदेन मौजूद नहीं"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, fuzzy, csharp-format
 msgid "Transfer From {0}"
 msgstr "धनराशि ट्रांसफ़र करें"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, fuzzy, csharp-format
 msgid "Transfer To {0}"
 msgstr "धनराशि ट्रांसफ़र करें"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "प्रकार"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 #, fuzzy
 msgid "Unable to export account to file."
 msgstr "खुले खाते को अधिलेखित (ओवरराइड) करने में असमर्थ"
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Unable to login to account. Provided password is invalid."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "खुले खाते को अधिलेखित (ओवरराइड) करने में असमर्थ"
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "खुले खाते को अधिलेखित (ओवरराइड) करने में असमर्थ"
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Update Only Source"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Update Source and Generated"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Update Transaction"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "हाँ"
 
@@ -784,19 +804,19 @@ msgstr "हाँ"
 msgid "Your system reported that your currency is"
 msgstr "Your system reported that your currency is"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "नमस्ते!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 #, fuzzy
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "नमस्ते!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -942,68 +962,82 @@ msgstr "समूह फ़िल्टर रीसेट करें"
 msgid "Unselect Groups Filters"
 msgstr "समूह फ़िल्टर रीसेट करें"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "समूह फ़िल्टर रीसेट करें"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "समूह फ़िल्टर रीसेट करें"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "पंचांग"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "दायरे का चयन करें"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "आरंभ"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "अंत"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 #, fuzzy
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "नई लेनदेन"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1018,8 +1052,8 @@ msgid "Color"
 msgstr "रंग"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 #, fuzzy
 msgid "Delete"
 msgstr "समूह हटाएँ"
@@ -1339,21 +1373,25 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 #, fuzzy
 msgid "Enter notes here"
 msgstr "Enter code here"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "लेनदेन में परिवर्तन करें"
 

--- a/NickvisionMoney.Shared/Resources/po/hr.po
+++ b/NickvisionMoney.Shared/Resources/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(kopija)"
 
@@ -28,8 +28,16 @@ msgstr "(kopija)"
 msgid "{0} from {1}"
 msgstr "{0} od {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Nijedan račun nije otvoren"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Postavke računa"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Vrsta računa"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Add"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Dodaj novu transakciju ili uvezi transakciju iz datoteke."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "PDF-u dodati lozinku?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Sve datoteke"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Iznos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Iznos (neispravan)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Primijeni"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Stvarno želiš izbrisati ovu grupu?\n"
 "Ovo je nepovratna radnja."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Stvarno želiš izbrisati ovu transakciju?\n"
 "Ovo je nepovratna radnja."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -131,9 +139,9 @@ msgstr "Poslovni"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Nije moguće pristupiti odabranoj mapi, provjeri dozvole za Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Odustani"
 
@@ -142,18 +150,18 @@ msgstr "Odustani"
 msgid "Change Password"
 msgstr "Promijeni lozinku"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Tekući"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Valuta"
@@ -191,16 +199,16 @@ msgstr "Znak valute (prazno)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Znak valute (neispravno)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Datum"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -223,42 +231,42 @@ msgstr "Decimalni znak (prazan)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Decimalni znak (neispravan)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Izbriši potojeće"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Izbriši grupu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Izbriši samo izvornu transakciju"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Izbriši izvornu transakciju i generirane transakcije"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Izbriši transakciju"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Opis"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Opis (prazan)"
 
@@ -284,13 +292,13 @@ msgstr "Lozinka za odredišni račun (neispravno)"
 msgid "Destination Account Password (Required)"
 msgstr "Lozinka za odredišni račun (obavezno)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Odspoji postojeće"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -299,50 +307,50 @@ msgstr "Odspoji postojeće"
 msgid "Expense"
 msgstr "Rashod"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Izvezi u datoteku"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Račun je uspješno izvezen u datoteku."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Stvoreno: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub repozitorij"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Dobar dan!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Dobar dan!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Dobra večer!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grupa"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Ime grupe"
 
@@ -360,19 +368,19 @@ msgstr "Znak odvajanja grupe"
 msgid "Group Separator (Invalid)"
 msgstr "Znak odvajanja grupe (neispravan)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupe"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Pomoć"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "ID"
 
@@ -381,22 +389,22 @@ msgstr "ID"
 msgid "Import from Account"
 msgstr "Uvezi iz datoteke"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Uvezi iz datoteke"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, fuzzy, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Uvezena je {0} transakcija iz datoteke."
 msgstr[1] "Uvezena je {0} transakcija iz datoteke."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -405,24 +413,24 @@ msgstr[1] "Uvezena je {0} transakcija iz datoteke."
 msgid "Income"
 msgstr "Prihod"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Upravljaj osobnim financijama"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Chat na Matrixu"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "--"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -437,98 +445,98 @@ msgstr "Ime (prazno)"
 msgid "Name (Exists)"
 msgstr "Ime (postoji)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nikada"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro račun"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Ne"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Bez krajnjeg datuma"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Nema transakcija"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Nije pronađena nijedna transakcija"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Nijedna transakcija ne odgovora zadanim filtrima."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Bilješke"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Otvori"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Otvori račun"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Pregled"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "{0}. stranica"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "PDF lozinka"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Priznanica"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Priznanice"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Krajnji datum ponavljanja"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Krajnji datum ponavljanja (neispravno)"
 
@@ -537,11 +545,11 @@ msgstr "Krajnji datum ponavljanja (neispravno)"
 msgid "Repeat Interval"
 msgstr "Interval ponavljanja"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Interval ponavljanja promijenjen"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -563,23 +571,29 @@ msgstr "Odaberi mapu sigurnosne kopije"
 msgid "Select Folder"
 msgstr "Odaberi mapu sigurnosne kopije"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Razvrstaj po iznosu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Razvrstaj po datumu"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Razvrstaj po ID-u"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Lozinka računa je promijenjena."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Lozinka računa je uklonjena."
 
@@ -591,7 +605,7 @@ msgstr "Lozinka će se ukloniti nakon zatvaranja dijaloga."
 msgid "The passwords do not match."
 msgstr "Lozinke se ne poklapaju."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -603,15 +617,15 @@ msgstr ""
 "\n"
 "Nove ponovljajuće transakcije generirat će se na temelju novog intervala."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Na ovom računu nema novca za transferiranje."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Ovaj je račun već otvoren."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -626,7 +640,7 @@ msgstr ""
 "Brisanje samo izvorne transakcije omogućit će mijenjanje\n"
 "pojedinačno generiranih transakcija."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -640,120 +654,126 @@ msgstr ""
 "Aktualiziranje samo izvorne transakcije će odspojiti\n"
 "iz izvora generirane transakcije."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Ukupno"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transakcija"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transakcije"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transakcije bez grupe"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transferiraj sa {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transferiraj na {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Vrsta"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Nije moguće izvesti račun u datoteku."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Neuspjela prijava na račun. Navedena lozinka je neispravna."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Nije moguće prepisati otvoreni račun."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Nije moguće prepisati otvoreni račun."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Negrupirano"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Aktualiziraj samo izvornu transakciju"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Aktualiziraj izvornu transakciju i generirane transakcije"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Aktualiziraj transakciju"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Prenesi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Prikaz"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -763,9 +783,9 @@ msgstr ""
 "\n"
 "Ako se lozinka izgubi, PDF neće biti dostupan."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Da"
 
@@ -774,18 +794,18 @@ msgstr "Da"
 msgid "Your system reported that your currency is"
 msgstr "Tvoj sustav je prijavio da je tvoja valuta"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Dobro jutro!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Dobro jutro!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -933,68 +953,83 @@ msgstr "Resetiraj filtre grupa"
 msgid "Unselect Groups Filters"
 msgstr "Resetiraj filtre grupa"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Uključi/isključi vidljivost grupa"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Resetiraj filtre grupa"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Resetiraj filtre grupa"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalendar"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Odaberi raspon"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Početak"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "Kraj"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Razvrstaj od prve prema zadnjoj"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Razvrstaj od zadnje prema prvoj"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nova transakcija (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Novo"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1008,8 +1043,8 @@ msgid "Color"
 msgstr "Boja"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Izbriši"
 
@@ -1327,20 +1362,24 @@ msgstr "Koristi boju grupe"
 msgid "Use unique color"
 msgstr "Koristi jedinstvenu boju"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Dodatno"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Upravljaj dodatnim poljima transakcije."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Upiši bilješke ovdje"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Uredi transakciju"
 

--- a/NickvisionMoney.Shared/Resources/po/id.po
+++ b/NickvisionMoney.Shared/Resources/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-06-07 19:40+0000\n"
 "Last-Translator: Krindog7337 <igstkrisna2006@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Salin)"
 
@@ -31,8 +31,15 @@ msgstr "(Salin)"
 msgid "{0} from {1}"
 msgstr "{0} dari {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -55,58 +62,58 @@ msgstr "Tidak Ada Rekening yang Terbuka"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Pengaturan Rekening"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Tipe Rekening"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Add"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Tambahkan transaksi baru atau impor transaksi dari berkas."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Tambahkan kata sandi ke PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Semua Berkas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Jumlah"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Jumlah (Tidak Sah)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Terapkan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -114,7 +121,7 @@ msgstr ""
 "Apakah anda yakin ingin menghapus grup ini?\n"
 "Tindakan ini tidak dapat diurungkan."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -122,7 +129,7 @@ msgstr ""
 "Apakah anda yakin ingin menghapus transaksi ini?\n"
 "Tindakan ini tidak dapat diurungkan."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -132,9 +139,9 @@ msgstr "Bisnis"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Tidak dapat mengakses folder yang dipilih, periksa perizinan Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Batal"
 
@@ -143,13 +150,13 @@ msgstr "Batal"
 msgid "Change Password"
 msgstr "Ubah Kata Sandi"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Giro"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -157,7 +164,7 @@ msgstr ""
 "Kontributor di GitHub ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Mata Uang"
@@ -195,16 +202,16 @@ msgstr "Simbol Mata Uang (kosong)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Simbol Mata Uang (Tidak sah)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Tanggal"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -227,41 +234,41 @@ msgstr "pemisah Desimal (kosong)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Pemisah Desimal (Tidak sah)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Hapus yang Ada"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Hapus Grup"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Hapus Hanya Sumber"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Hapus Sumber dan yang Dihasilkan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Hapus Transaksi"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Deskripsi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Deskripsi (Kosong)"
 
@@ -287,13 +294,13 @@ msgstr "Kata Sandi Rekening Tujuan (Tidak Valid)"
 msgid "Destination Account Password (Required)"
 msgstr "Kata Sandi Rekening Tujuan (Diperlukan)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Pisahkan yang Ada"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -302,50 +309,50 @@ msgstr "Pisahkan yang Ada"
 msgid "Expense"
 msgstr "Pengeluaran"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Ekspor ke Berkas\t"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Ekspor rekening ke berkas berhasil."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Dihasilkan: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repo Github"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Selamat Siang!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Halo!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Selamat Malam!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grup"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nama Grup"
 
@@ -363,19 +370,19 @@ msgstr "Pemisah Grup"
 msgid "Group Separator (Invalid)"
 msgstr "Pemisah Grup (tidak sah)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grup"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Bantuan"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -384,21 +391,21 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "Impor dari Berkas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Impor dari Berkas"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Mengimpor {0} transaksi dari berkas."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +414,24 @@ msgstr[0] "Mengimpor {0} transaksi dari berkas."
 msgid "Income"
 msgstr "Pemasukan"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Kelola keuangan pribadi anda"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Obrolan Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +446,98 @@ msgstr "Nama (Kosong)"
 msgid "Name (Exists)"
 msgstr "Nama (Telah digunakan)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Tidak Pernah"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Rekening Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Tidak"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Tidak Ada Tanggal Akhir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Tidak Ada Transaksi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Tidak Ada Transaksi yang Ditemukan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Tidak ada transaksi yang sesuai dengan filter."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Catatan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Buka"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Buka Rekening"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Gambaran"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Halaman"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Kata Sandi PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Kuitansi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Kwitansi (Berkas tidak dapat diakses)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Kuitansi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Batas Akhir Pengulangan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Batas Akhir Pengulangan (Tidak Sah)"
 
@@ -539,11 +546,11 @@ msgstr "Batas Akhir Pengulangan (Tidak Sah)"
 msgid "Repeat Interval"
 msgstr "Interval Pengulangan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Interval Pengulangan diubah"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -563,23 +570,29 @@ msgstr "Pilih Folder Cadangan"
 msgid "Select Folder"
 msgstr "Pilih Folder"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Urutkan Berdasarkan Jumlah"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Urutkan Berdasarkan Tanggal"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Urutkan Berdasarkan Id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Kata sandi pada rekening ini telah diubah."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Kata sandi pada rekening ini telah dihapus."
 
@@ -591,7 +604,7 @@ msgstr "Kata sandi akan dihapus setelah menutup dialog ini."
 msgid "The passwords do not match."
 msgstr "Kata sandi tidak cocok."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -604,15 +617,15 @@ msgstr ""
 "Transaksi berulang yang baru akan dihasilkan berdasarkan interval "
 "pengulangan yang baru."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Rekening ini tidak mempunyai uang untuk ditransfer."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Rekening ini sudah dibuka."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -627,7 +640,7 @@ msgstr ""
 "Hanya menghapus transaksi sumber akan membuat transaksi&#xA;yang telah "
 "dihasilkan untuk dimodifikasi."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -641,54 +654,54 @@ msgstr ""
 "Hanya memperbarui transaksi sumber akan memisahkan \n"
 "transaksi yang telah dihasilkan dari sumber."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transaksi"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transaksi"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transaksi Tanpa Grup"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transfer dari {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transfer ke {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tipe"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Tidak dapat mengekspor rekening ke berkas."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -696,17 +709,17 @@ msgstr ""
 "Tidak dapat mengimpor informasi dari berkas. Pastikan aplikasi memiliki izin "
 "untuk mengakses file dan coba lagi."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 "Tidak dapat mengimpor informasi dari berkas. Tipe berkas tidak didukung."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Tidak dapat masuk ke rekening. Sandi yang diberikan tidak valid."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -714,52 +727,58 @@ msgstr ""
 "Tidak dapat membuka rekening. Pastikan aplikasi memiliki izin untuk "
 "mengakses file dan coba lagi."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Tidak dapat mengesampingkan rekening yang terbuka."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Tidak dapat mengesampingkan rekening yang terbuka."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Tidak digrup"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Perbarui Hanya Sumber"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Perbarui Sumber dan yang Dihasilkan"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Perbarui Transaksi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Unggah"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Lihat"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -769,9 +788,9 @@ msgstr ""
 "\n"
 "Jika kata sandi hilang, file PDF tidak akan bisa diakses."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Ya"
 
@@ -780,18 +799,18 @@ msgstr "Ya"
 msgid "Your system reported that your currency is"
 msgstr "Sistem anda melaporkan bahwa mata uang anda adalah"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Selamat Pagi!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Selamat Pagi!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -938,65 +957,80 @@ msgstr "Atur Ulang Filter Grup"
 msgid "Unselect Groups Filters"
 msgstr "Atur Ulang Filter Grup"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Jungkitkan Tampilnya Grup"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Atur Ulang Filter Grup"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Atur Ulang Filter Grup"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalender"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Pilih Rentang"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Mulai"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Akhir"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Selanjutnya"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Urutkan dari awal ke akhir"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Urutkan dari akhir ke awal"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Transaksi Baru (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Baru"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Saran"
 
@@ -1010,8 +1044,8 @@ msgid "Color"
 msgstr "Warna"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Hapus"
 
@@ -1325,20 +1359,24 @@ msgstr "Gunakan warna grup"
 msgid "Use unique color"
 msgstr "Gunakan warna unik"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Tambahan"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Kelola menu tambahan transaksi."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Masukkan catatan disini"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Edit Transaksi"
 

--- a/NickvisionMoney.Shared/Resources/po/it.po
+++ b/NickvisionMoney.Shared/Resources/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-06-17 02:34+0000\n"
 "Last-Translator: Nick Logozzo <nlogozzo225@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copia)"
 
@@ -31,8 +31,16 @@ msgstr "(Copia)"
 msgid "{0} from {1}"
 msgstr "{0} da {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -56,58 +64,58 @@ msgstr "Nessun account aperto"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Impostazioni account"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Tipo di conto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Aggiungi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Creare una nuova transazione o importare le transazioni da un file."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Aggiungere una password al PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Tutti i file"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Importo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Importo (non valido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Applica"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +123,7 @@ msgstr ""
 "Eliminare il gruppo?\n"
 "L'azione è irreversibile."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +131,7 @@ msgstr ""
 "Eliminare la transazione?\n"
 "L'azione è irreversibile."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -135,9 +143,9 @@ msgstr ""
 "Impossibile accedere alla cartella selezionata, controllare i permessi di "
 "Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -146,13 +154,13 @@ msgstr "Annulla"
 msgid "Change Password"
 msgstr "Modifica password"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Conto corrente"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -160,7 +168,7 @@ msgstr ""
 "I collaboratori di GitHub ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Valuta"
@@ -198,16 +206,16 @@ msgstr "Simbolo della valuta (vuoto)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Simbolo della valuta (non valido)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Data"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -230,41 +238,41 @@ msgstr "Separatore decimale (vuoto)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Separatore decimale (non valido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Elimina esistenti"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Elimina gruppo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Elimina solo l'originale"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Elimina l'originale e quelle generate"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Elimina transazione"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Descrizione"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Descrizione (vuota)"
 
@@ -290,13 +298,13 @@ msgstr "Password del conto di destinazione (non valida)"
 msgid "Destination Account Password (Required)"
 msgstr "Password del conto di destinazione (richiesta)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Scollega esistenti"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -305,50 +313,50 @@ msgstr "Scollega esistenti"
 msgid "Expense"
 msgstr "Uscita"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Esporta su file"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "L'account è stato esportato su file."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Generate: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repository GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Buon pomeriggio!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Buongiorno!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Buona sera!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Gruppo"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nome gruppo"
 
@@ -366,19 +374,19 @@ msgstr "Separatore dei gruppi"
 msgid "Group Separator (Invalid)"
 msgstr "Separatore dei gruppi (non valido)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Gruppi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "ID"
 
@@ -387,22 +395,22 @@ msgstr "ID"
 msgid "Import from Account"
 msgstr "Importa da file"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importa da file"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "{0} transazione importata dal file."
 msgstr[1] "{0} transazioni importate dal file."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -411,24 +419,24 @@ msgstr[1] "{0} transazioni importate dal file."
 msgid "Income"
 msgstr "Entrata"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Gestisci le tue finanze"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Chat di Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -443,99 +451,99 @@ msgstr "Nome (vuoto)"
 msgid "Name (Exists)"
 msgstr "Nome (esistente)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Mai"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Conto di Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "No"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Per sempre"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Nessuna transazione"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Nessuna transazione trovata"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 "Non è stata trovata alcuna transazione che corrisponda ai filtri selezionati."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Annotazioni"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Apri"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Apre un conto"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Panoramica"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Pagina {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Password del PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Ricevuta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Ricevuta (File inaccessibile)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Ricevute"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Fine ripetizione"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Fine ripetizione (non valida)"
 
@@ -544,11 +552,11 @@ msgstr "Fine ripetizione (non valida)"
 msgid "Repeat Interval"
 msgstr "Frequenza"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "La frequenza è stata modificata"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -568,23 +576,29 @@ msgstr "Seleziona cartella di backup"
 msgid "Select Folder"
 msgstr "Seleziona cartella"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Ordina per importo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Ordina per data"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Ordina per ID"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "La password del conto è stata modificata."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "La password del conto è stata eliminata."
 
@@ -596,7 +610,7 @@ msgstr "La password sarà eliminata alla chiusura di questa finestra."
 msgid "The passwords do not match."
 msgstr "Le password non combaciano."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -608,15 +622,15 @@ msgstr ""
 "\n"
 "Verranno generate nuove transazioni ripetute in base alla nuova frequenza."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Questo conto non ha sufficiente denaro per il trasferimento."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Questo account è già aperto."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -631,7 +645,7 @@ msgstr ""
 "Eliminare solo la transazione ricorrente permetterà di modificare "
 "singolarmente le transazioni ad essa collegate."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -645,56 +659,56 @@ msgstr ""
 "Aggiornare solo la transazione ricorrente scollegherà\n"
 "le transazioni ad essa collegate."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Totale"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transazioni"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transazioni"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transazioni senza gruppo"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Trasferimento da {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Trasferimento a {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 "Mattia Borda\n"
 "Davide Ferracin <davide.ferracin@protonmail.com>"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Esportazione su file del conto non riuscita."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -702,18 +716,18 @@ msgstr ""
 "Importazione delle informazioni dal file non riuscita. Assicurarsi che "
 "l'applicazione abbia i permessi di accedere al file e riprovare."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 "Importazione delle informazioni dal file non riuscita. Il tipo di file non è "
 "supportato."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Accesso al conto non riuscito. La password non è corretta."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -721,52 +735,58 @@ msgstr ""
 "Apertura del conto non riuscita. Assicurarsi che l'applicazione abbia i "
 "permessi di accedere al file e riprovare."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Non è possibile sovrascrivere un account aperto."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Non è possibile sovrascrivere un account aperto."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Senza gruppo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Aggiorna solo l'originale"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Aggiorna originale e collegate"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Aggiorna transazione"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Carica"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Visualizza"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -776,9 +796,9 @@ msgstr ""
 "\n"
 "Se la password viene dimenticata, non sarà possibile aprire il PDF."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Sì"
 
@@ -787,18 +807,18 @@ msgstr "Sì"
 msgid "Your system reported that your currency is"
 msgstr "Il sistema riferisce che la valuta di sistema è"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Buongiorno!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Buongiorno!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -943,65 +963,80 @@ msgstr "Seleziona tutti i filtri dei gruppi"
 msgid "Unselect Groups Filters"
 msgstr "Deseleziona filtri dei gruppi"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Mostra/nascondi gruppi"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Seleziona tutti i filtri dei gruppi"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Deseleziona filtri dei gruppi"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Calendario"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Reimposta ad oggi"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Oggi"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Seleziona periodo"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Inizio"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Fine"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Successivo"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Ordina dalla meno recente"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Ordina dalla più recente"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nuova transazione (Ctrl+Maiusc+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nuova"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Suggerimenti"
 
@@ -1015,8 +1050,8 @@ msgid "Color"
 msgstr "Colore"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Elimina"
 
@@ -1329,20 +1364,24 @@ msgstr "Usa colore del gruppo"
 msgid "Use unique color"
 msgstr "Usa colore speciale"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extra"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Gestisce i campi extra della transazione."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Inserire le note qui"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Modifica transazione"
 

--- a/NickvisionMoney.Shared/Resources/po/ja.po
+++ b/NickvisionMoney.Shared/Resources/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-07-09 22:27+0000\n"
 "Last-Translator: Luci Draws <dpkg.luci@protonmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/nickvision-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(コピー)"
 
@@ -31,8 +31,15 @@ msgstr "(コピー)"
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,70 +61,70 @@ msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr ""
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -127,9 +134,9 @@ msgstr ""
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -138,18 +145,18 @@ msgstr "キャンセル"
 msgid "Change Password"
 msgstr ""
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr ""
@@ -187,16 +194,16 @@ msgstr ""
 msgid "Currency Symbol (Invalid)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "デーツ"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -219,41 +226,41 @@ msgstr ""
 msgid "Decimal Separator (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "デナロ"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr ""
 
@@ -279,13 +286,13 @@ msgstr ""
 msgid "Destination Account Password (Required)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -294,50 +301,50 @@ msgstr ""
 msgid "Expense"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr ""
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr ""
 
@@ -355,19 +362,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr ""
 
@@ -375,22 +382,22 @@ msgstr ""
 msgid "Import from Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -399,24 +406,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix チャット"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -431,98 +438,98 @@ msgstr ""
 msgid "Name (Exists)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "いいえ"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr ""
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr ""
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr ""
 
@@ -531,11 +538,11 @@ msgstr ""
 msgid "Repeat Interval"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr ""
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -555,23 +562,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr ""
 
@@ -583,7 +596,7 @@ msgstr ""
 msgid "The passwords do not match."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -591,15 +604,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -608,7 +621,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -617,127 +630,133 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr ""
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr ""
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr ""
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "はい"
 
@@ -746,18 +765,18 @@ msgstr "はい"
 msgid "Your system reported that your currency is"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -899,65 +918,77 @@ msgstr ""
 msgid "Unselect Groups Filters"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+msgid "Select All Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+msgid "Unselect Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -971,8 +1002,8 @@ msgid "Color"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr ""
 
@@ -1273,20 +1304,24 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr ""
 

--- a/NickvisionMoney.Shared/Resources/po/nl.po
+++ b/NickvisionMoney.Shared/Resources/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-07-05 16:50+0000\n"
 "Last-Translator: Philip Goto <philip.goto@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(kopie)"
 
@@ -31,8 +31,16 @@ msgstr "(kopie)"
 msgid "{0} from {1}"
 msgstr "{0} van {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Accountnaam (geopend)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Rekeninginstellingen"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Soort rekening"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Toevoegen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Voeg een transactie toe of importeer deze uit een bestand"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Wachtwoord toevoegen aan PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Bedrag"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Bedrag (ongeldig)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Toepassen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Weet u zeker dat u deze groep wilt verwijderen?\n"
 "Deze actie is onomkeerbaar."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Weet u zeker dat u deze transactie wilt verwijderen?\n"
 "Deze actie is onomkeerbaar.."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -131,9 +139,9 @@ msgstr "Zakelijk"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Geen toegang tot de geselecteerde map, controleer Flatpak-rechten."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -142,13 +150,13 @@ msgstr "Annuleren"
 msgid "Change Password"
 msgstr "Wachtwoord wijzigen"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Cheques"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -156,7 +164,7 @@ msgstr ""
 "Contributors on GitHub ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Valuta"
@@ -194,16 +202,16 @@ msgstr "Valutasymbool (blanco)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Valutasymbool (ongeldig)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Datum"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -226,41 +234,41 @@ msgstr "Decimaal scheidingsteken (leeg)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Decimaal scheidingsteken (ongeldig)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Bestaande verwijderen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Groep verwijderen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Alleen eerste verwijderen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Ook alle opeenvolgende verwijderen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Transactie verwijderen"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Beschrijving"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Beschrijving (blanco)"
 
@@ -286,13 +294,13 @@ msgstr "Wachtwoord van bestemmingsaccount (ongeldig)"
 msgid "Destination Account Password (Required)"
 msgstr "Wachtwoord van bestemmingsaccount (vereist)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Huidige loskoppelen"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -301,50 +309,50 @@ msgstr "Huidige loskoppelen"
 msgid "Expense"
 msgstr "Uitgave"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exporteren naar bestand"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "De rekening is geëxporteerd naar een bestand."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Gegenereerd: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub-repo"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Goedemiddag!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Goedendag!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Goedenavond!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Groep"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Groepsnaam"
 
@@ -362,19 +370,19 @@ msgstr "Groepsscheidingsteken"
 msgid "Group Separator (Invalid)"
 msgstr "Groepsscheidingsteken (ongeldig)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Groepen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hulp"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "ID"
 
@@ -382,22 +390,22 @@ msgstr "ID"
 msgid "Import from Account"
 msgstr "Importeren uit account"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importeren uit bestand"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "{0} transactie uit bestand geïmporteerd"
 msgstr[1] "{0} transacties uit bestand geïmporteerd"
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -406,24 +414,24 @@ msgstr[1] "{0} transacties uit bestand geïmporteerd"
 msgid "Income"
 msgstr "Inkomst"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Beheer uw persoonlijke financiën"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix-kamer"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "n/b"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -438,99 +446,99 @@ msgstr "Naam (blanco)"
 msgid "Name (Exists)"
 msgstr "Naam (bestaat)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nooit"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro-account"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Nee"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Geen einddatum"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Geen transacties"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Geen transacties gevonden"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 "Er zijn geen transacties gevonden die voldoen aan de opgegeven filters."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Aantekeningen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Openen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Account openen"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Overzicht"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Pagina {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "PDF-wachtwoord"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Factuur"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Factuur (bestand niet toegankelijk)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Facturen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Einddatum herhaling"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Einddatum herhaling (ongeldig)"
 
@@ -539,11 +547,11 @@ msgstr "Einddatum herhaling (ongeldig)"
 msgid "Repeat Interval"
 msgstr "Herhalingsinterval"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "De herhaalperiode is gewijzigd"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -563,23 +571,29 @@ msgstr "Back-up-map selecteren"
 msgid "Select Folder"
 msgstr "Map selecteren"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Sorteren op hoeveelheid"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Sorteren op datum"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Sorteren op id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Het wachtwoord van het account is gewijzigd"
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Het wachtwoord van het account is verwijderd"
 
@@ -591,7 +605,7 @@ msgstr "Het wachtwoord zal worden verwijderd bij het sluiten van deze dialoog"
 msgid "The passwords do not match."
 msgstr "Wachtwoorden komen niet overeen"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -604,15 +618,15 @@ msgstr ""
 "Nieuwe opeenvolgende transacties worden op basis van de nieuwe periode "
 "ingepland."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Er staat geen geld op deze rekening."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Dit account is al geopend"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -627,7 +641,7 @@ msgstr ""
 "Als u alleen de eerste transactie verwijdert, blijven\n"
 "de opeenvolgende aanpasbaar."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -641,120 +655,126 @@ msgstr ""
 "Als u alleen de eerste transactie bijwerkt, worden\n"
 "de opeenvolgende losgekoppeld.."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Totaal"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transactie"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transacties"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transacties die geen deel uitmaken van een groep"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Overmaken van {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Overmaken naar {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Philip Goto https://philipgoto.nl/"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Type"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "De rekening kan niet worden geëxporteerd."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Kan niet inloggen met dit account. Opgegeven wachtwoord is ongeldig."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Een account kan slechts eenmaal worden geopend."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Een account kan slechts eenmaal worden geopend."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Ongegroepeerd"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Alleen eerste bijwerken"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Ook alle opeenvolgende transacties bijwerken"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Transactie bijwerken"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Uploaden"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Bekijken"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -765,9 +785,9 @@ msgstr ""
 "Als het wachtwoord verloren is zal het PDF-bestand niet meer toegankelijk "
 "zijn."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Ja"
 
@@ -776,18 +796,18 @@ msgstr "Ja"
 msgid "Your system reported that your currency is"
 msgstr "Volgens uw besturingssysteem is uw valuta"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Goedemorgen!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Goedenacht!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -931,65 +951,80 @@ msgstr "Alle groepsfilters selecteren"
 msgid "Unselect Groups Filters"
 msgstr "Groepfilters deselecteren"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Groepen tonen/verbergen"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Alle groepsfilters selecteren"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Groepfilters deselecteren"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Agenda"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Terugzetten naar vandaag"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Vandaag"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Kies een datumbereik"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Begin"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Eind"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Volgende"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Oplopend sorteren"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Aflopend sorteren"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nieuwe overboeking (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nieuw"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Suggesties"
 
@@ -1003,8 +1038,8 @@ msgid "Color"
 msgstr "Kleur"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -1315,20 +1350,24 @@ msgstr "Groepskleur gebruiken"
 msgid "Use unique color"
 msgstr "Unieke kleur gebruiken"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extra's"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Beheer extra velden van de transactie"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Voer aantekeningen hier in"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Transactie bewerken"
 

--- a/NickvisionMoney.Shared/Resources/po/oc.po
+++ b/NickvisionMoney.Shared/Resources/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copiar)"
 
@@ -28,8 +28,16 @@ msgstr "(Copiar)"
 msgid "{0} from {1}"
 msgstr "{0} de {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,60 +62,60 @@ msgstr "Cap de compte pas dobèrt"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Paramètres del compte"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Tipe de compte"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Ajustar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 "Ajustatz una transaccion novèla o importatz de transaccions a partir d’un "
 "fichièr."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Ajustar un senhal al document PDF ?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Totes los fichièrs"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Soma"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Soma (invalida)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +123,7 @@ msgstr ""
 "Volètz vertadièrament suprimir aqueste grop ?\n"
 "Aquesta accion se pòt pas anullar."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +131,7 @@ msgstr ""
 "Volètz vertadièrament suprimir aquesta transaccion ?\n"
 "Aquesta accion se pòt pas anullar."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +141,9 @@ msgstr "Afars"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Anullar"
 
@@ -144,18 +152,18 @@ msgstr "Anullar"
 msgid "Change Password"
 msgstr "Cambiar lo senhal"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Chècs"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Devisa"
@@ -194,16 +202,16 @@ msgstr "Currency Symbol (Empty)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Currency Symbol (Empty)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Data"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -229,42 +237,42 @@ msgstr "Inserir un separador decimal"
 msgid "Decimal Separator (Invalid)"
 msgstr "Inserir un separador decimal"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Suprimir l’existent"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Suprimir lo grop"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Suprimir sonque la font"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Suprimir la font e las transaccions generadas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Suprimir la transaccion"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Descripcion"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Descripcion (voida)"
 
@@ -290,13 +298,13 @@ msgstr "Senhal del compte de destinacion (invalid)"
 msgid "Destination Account Password (Required)"
 msgstr "Senhal del compte de destinacion (obligatòri)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Dissociar l’existent"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -305,50 +313,50 @@ msgstr "Dissociar l’existent"
 msgid "Expense"
 msgstr "Despensa"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exportar cap a un fichièr"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Compte corrèctament exportat dins un fichièr."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Generat : {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Depaus GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Bon aprèp-miègjorn"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Bona jornada"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Bonser"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grop"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nom del grop"
 
@@ -367,19 +375,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr "Soma (invalida)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grops"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Identificant"
 
@@ -388,22 +396,22 @@ msgstr "Identificant"
 msgid "Import from Account"
 msgstr "Importar d’un fichièr estant"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importar d’un fichièr estant"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, fuzzy, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "{0} transaccion importada del fichièr estant."
 msgstr[1] "{0} transaccion importada del fichièr estant."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -412,24 +420,24 @@ msgstr[1] "{0} transaccion importada del fichièr estant."
 msgid "Income"
 msgstr "Revengut"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Gerissètz vòstras finanças personalas"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/D"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -444,98 +452,98 @@ msgstr "Nom (void)"
 msgid "Name (Exists)"
 msgstr "Nom (existís)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Pas jamai"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Compte Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Non"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Cap de data de fin"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Cap de transaccion"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Cap de transaccion pas trobada"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Cap de transaccion correspondenta als filtres especificats."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Nòtas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Dobrir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Dobrir compte"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Vista d'ensemble"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Pagina {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Senhal PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Recebut"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Recebuts"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Repetir la data de fin"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Repetir la data de fin (invalida)"
 
@@ -544,11 +552,11 @@ msgstr "Repetir la data de fin (invalida)"
 msgid "Repeat Interval"
 msgstr "Interval de repeticion"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Interval de repeticion modificat"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -570,23 +578,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr "Seleccionar l’interval"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Triar per soma"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Triar per data"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Triar per identificant"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Lo senhal del compte es estat modificat."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Lo senhal del compte es estat tirat."
 
@@ -599,7 +613,7 @@ msgstr "Serà tirat lo senhal a la tampadura de la bóstia de dialòg."
 msgid "The passwords do not match."
 msgstr "Lo senhal del compte es estat modificat."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -607,15 +621,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Aqueste compte a pas cap d’argent disponible per transferir."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Aqueste compte es ja dobèrt."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -624,7 +638,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -633,120 +647,126 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transaccion"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transaccions"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transaccion sens grop"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transferir a partir de {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transferir cap a {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tipe"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Exportacion dins un fichièr del compte impossible."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Connexion al compte impossibla. Lo senhal fornit es invalid."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Impossible de subrecargar un compte dobèrt."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Impossible de subrecargar un compte dobèrt."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Pas gropada"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Actualizar sonque la font"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Actualizar la font e las transaccions generadas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Actualizar la transaccion"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Enviar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Afichatge"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -756,9 +776,9 @@ msgstr ""
 "\n"
 "En cas de pèrda del senhal lo document serà inaccessible."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Òc"
 
@@ -767,18 +787,18 @@ msgstr "Òc"
 msgid "Your system reported that your currency is"
 msgstr "Segon vòstre sistèma vòstra devisa es"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Bonjorn"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Bonjorn"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -925,68 +945,83 @@ msgstr "Reïnicializar los filtres de grops"
 msgid "Unselect Groups Filters"
 msgstr "Reïnicializar los filtres de grops"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Bascular la visibilitat dels grops"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Reïnicializar los filtres de grops"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Reïnicializar los filtres de grops"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Calendièr"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Seleccionar l’interval"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Debuta"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "Fin"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Triar del primièr al darnièr"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Triar del darnièr al primièr"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Transaccion novèla (Ctrl+Maj+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Novèla"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1000,8 +1035,8 @@ msgid "Color"
 msgstr "Color"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Suprimir"
 
@@ -1327,21 +1362,25 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extras"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 #, fuzzy
 msgid "Enter notes here"
 msgstr "Dintratz lo nom aicí"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Modificar la transaccion"
 

--- a/NickvisionMoney.Shared/Resources/po/pl.po
+++ b/NickvisionMoney.Shared/Resources/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-08-10 15:58+0000\n"
 "Last-Translator: Dominik Gęgotek <ioutora@disroot.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/nickvision-money/"
@@ -20,7 +20,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Kopia)"
 
@@ -32,8 +32,17 @@ msgstr "(Kopia)"
 msgid "{0} from {1}"
 msgstr "{0} z {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -56,58 +65,58 @@ msgstr "Nazwa konta (otwarte)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Ustawienia konta"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Rodzaj konta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Dodaj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Dodaj nową transakcję lub zaimportuj transakcje z pliku."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Dodać hasło do pliku PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Wszystkie pliki"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Kwota"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Kwota (niepoprawna)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +124,7 @@ msgstr ""
 "Czy na pewno chcesz usunąć tę grupę?\n"
 "Tej czynności nie można cofnąć."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +132,7 @@ msgstr ""
 "Czy na pewno chcesz usunąć tę transakcję?\n"
 "Tej czynności nie można cofnąć."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +142,9 @@ msgstr "Firmowe"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Brak dostępu do wybranego folderu, sprawdź uprawnienia Flatpaka."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -144,18 +153,18 @@ msgstr "Anuluj"
 msgid "Change Password"
 msgstr "Zmień hasło"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Bieżące"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr "Współautorzy z GitHuba ❤️"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Waluta"
@@ -193,16 +202,16 @@ msgstr "Symbol waluty (pusty)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Symbol waluty (niepoprawny)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr "DaPigGuy"
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Data"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr "David Lapshin"
 
@@ -225,41 +234,41 @@ msgstr "Separator dziesiętny (pusty)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Separator dziesiętny (niepoprawny)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Usuń istniejące"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Usuń grupę"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Usuń tylko źródłową"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Usuń źródłową i wygenerowane"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Usuń transakcję"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Opis"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Opis (pusty)"
 
@@ -285,13 +294,13 @@ msgstr "Hasło konta docelowego (niepoprawne)"
 msgid "Destination Account Password (Required)"
 msgstr "Hasło konta docelowego (wymagane)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Rozdziel istniejące"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -300,50 +309,50 @@ msgstr "Rozdziel istniejące"
 msgid "Expense"
 msgstr "Wydatek"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Eksport do pliku"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Poprawnie wyeksportowano konto do pliku."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr "Fyodor Sobolev"
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Stworzono: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repozytorium na GitHubie"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Dzień dobry!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Dobrego dnia!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Dobry wieczór!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grupa"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nazwa grupy"
 
@@ -361,19 +370,19 @@ msgstr "Separator grup"
 msgid "Group Separator (Invalid)"
 msgstr "Separator grup (niepoprawny)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupy"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Pomoc"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Identyfikator (ID)"
 
@@ -381,13 +390,13 @@ msgstr "Identyfikator (ID)"
 msgid "Import from Account"
 msgstr "Import z konta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Import z pliku"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
@@ -395,9 +404,9 @@ msgstr[0] "Zaimportowano {0} transakcję z pliku."
 msgstr[1] "Zaimportowano {0} transakcje z pliku."
 msgstr[2] "Zaimportowano {0} transakcji z pliku."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -406,24 +415,24 @@ msgstr[2] "Zaimportowano {0} transakcji z pliku."
 msgid "Income"
 msgstr "Dochód"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Zarządzaj swoimi finansami"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Czat na Matriksie"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "nd."
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -438,98 +447,98 @@ msgstr "Nazwa (pusta)"
 msgid "Name (Exists)"
 msgstr "Nazwa (już istnieje)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nigdy"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr "Nicholas Logozzo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Konto Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Nie"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Bez daty końca"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Brak transakcji"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Nie znaleziono transakcji"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Żadna transakcja nie odpowiada zastosowanym filtrom."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Uwagi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Otwórz"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Otwórz konto"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Przegląd"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Strona {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Hasło do pliku PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "Transakcje są importowane, proszę czekać..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Potwierdzenie"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Potwierdzenie (plik niedostępny)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Potwierdzenia"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Data końca powtarzania"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Data końca powtarzania (niepoprawna)"
 
@@ -538,11 +547,11 @@ msgstr "Data końca powtarzania (niepoprawna)"
 msgid "Repeat Interval"
 msgstr "Interwał powtarzania"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Zmieniono interwał powtarzania"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -562,23 +571,29 @@ msgstr "Wybierz folder do kopii zapasowej"
 msgid "Select Folder"
 msgstr "Wybierz folder"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Sortuj po kwocie"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Sortuj po dacie"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Sortuj po ID"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Zmieniono hasło do konta."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Usunięto hasło do konta."
 
@@ -590,7 +605,7 @@ msgstr "Hasło zostanie usunięte po zamknięciu tego monitu."
 msgid "The passwords do not match."
 msgstr "Hasła nie są jednakowe."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -602,15 +617,15 @@ msgstr ""
 "\n"
 "Nowe transakcje powtarzane będą generowane zgodnie z nowym interwałem."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "To konto nie ma dostępnych środków do przelewu."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "To konto jest już otwarte."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -624,7 +639,7 @@ msgstr ""
 "Usunięcie tylko transakcji źródłowej pozwoli na to,\n"
 "aby poszczególne wygenerowane transakcje były edytowalne."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -638,54 +653,54 @@ msgstr ""
 "Zaktualizowanie tylko transakcji źródłowej \n"
 "rozdzieli od niej wygenerowane transakcje."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr "Tobias Bernard"
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Łącznie"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transakcja"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transakcje"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transakcje bez grupy"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Przelej z {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Przelej do {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Dominik Gęgotek <ioutora@disroot.org>, 2023"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Rodzaj"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Nie można eksportować konta do pliku."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -693,16 +708,16 @@ msgstr ""
 "Nie można zaimportować informacji z pliku. Upewnij się, że aplikacja ma "
 "uprawnienia dostępu do pliku i spróbuj ponownie."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr "Nie można zaimportować informacji z pliku. Nieobsługiwany typ pliku."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Nie można zalogować się na konto. Podane hasło jest nieprawidłowe."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -710,50 +725,56 @@ msgstr ""
 "Nie można utworzyć konta. Upewnij się, że aplikacja ma uprawnienia dostępu "
 "do pliku i spróbuj ponownie."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "Nie można nadpisać istniejącego konta."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "Nie można nadpisać otwartego konta."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Bez grupy"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Zaktualizuj tylko źródłową"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Zaktualizuj źródłową i wygenerowane"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Zaktualizuj transakcję"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Wgraj"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Pokaż"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -763,9 +784,9 @@ msgstr ""
 "\n"
 "Jeśli utracisz hasło, PDF będzie niedostępny."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Tak"
 
@@ -774,18 +795,18 @@ msgstr "Tak"
 msgid "Your system reported that your currency is"
 msgstr "Twój system zgłasza, że twoją walutą jest"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Dzień dobry!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Dzień dobry!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -927,65 +948,80 @@ msgstr "Wybierz wszystkie filtry grup"
 msgid "Unselect Groups Filters"
 msgstr "Odznacz filtry grup"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Ustaw widoczność grup"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Wybierz wszystkie filtry grup"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Odznacz filtry grup"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Kalendarz"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr "Wybierz obecny miesiąc"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Zresetuj do dzisiaj"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Dziś"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Wybierz zakres"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Początek"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Koniec"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr "Wizualizuj"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Dalej"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Sortuj od najnowszych"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Sortuj od najstarszych"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nowa transakcja (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Nowa"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Sugestie"
 
@@ -999,8 +1035,8 @@ msgid "Color"
 msgstr "Kolor"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Usuń"
 
@@ -1307,20 +1343,24 @@ msgstr "Użyj koloru grupy"
 msgid "Use unique color"
 msgstr "Użyj unikalnego koloru"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Dodatkowe"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Zarządzaj dodatkowymi polami transakcji."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Wpisz tu uwagi"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Edytuj transakcję"
 

--- a/NickvisionMoney.Shared/Resources/po/pt.po
+++ b/NickvisionMoney.Shared/Resources/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copiar)"
 
@@ -28,8 +28,16 @@ msgstr "(Copiar)"
 msgid "{0} from {1}"
 msgstr "{0} de {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Nenhuma Conta Aberta"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Configurações da Conta"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Account Type"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Criar uma nova transação ou importar transações de um ficheiro."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Adicionar palavra-passe ao PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Todos os ficheiros"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Valor"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Valor (inválido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Salvar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Tem certeza de que deseja excluir este grupo?\n"
 "Esta ação não pode ser desfeita."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Tem certeza de que deseja excluir esta transação?\n"
 "Esta ação não pode ser desfeita."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +141,9 @@ msgstr ""
 "Não é possível acessar a pasta selecionada. Verifique as permissões do "
 "Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -144,18 +152,18 @@ msgstr "Cancelar"
 msgid "Change Password"
 msgstr "Alterar Senha"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Verificando"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Currency"
@@ -193,16 +201,16 @@ msgstr "Símbolo da Moeda (Vazio)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Símbolo da moeda (inválido)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Data"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -225,42 +233,42 @@ msgstr "Separador decimal (vazio)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Separador decimal (inválido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Apagar Existentes"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Remover Grupo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Apagar Apenas Origem"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Apagar Origem e Gerado"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Apagar Transação"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Descrição"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Descrição (vazia)"
 
@@ -286,13 +294,13 @@ msgstr "Senha da Conta de Destino (Inválida)"
 msgid "Destination Account Password (Required)"
 msgstr "Senha da Conta de Destino (Obrigatório)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Desassociar Existentes"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -301,50 +309,50 @@ msgstr "Desassociar Existentes"
 msgid "Expense"
 msgstr "Despesas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exportar para Arquivo"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Conta exportada para ficheiro com sucesso."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Gerados: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repositório do GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Boa Tarde!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Bom Dia!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Boa Noite!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grupo"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nome do Grupo"
 
@@ -362,19 +370,19 @@ msgstr "Separador de grupo"
 msgid "Group Separator (Invalid)"
 msgstr "Separador de grupo (inválido)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -383,22 +391,22 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "Importar de um Arquivo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importar de um Arquivo"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, fuzzy, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Importada {0} transação do ficheiro."
 msgstr[1] "Importada {0} transação do ficheiro."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +415,24 @@ msgstr[1] "Importada {0} transação do ficheiro."
 msgid "Income"
 msgstr "Rendimentos"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Gerencie suas finanças pessoais"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +447,98 @@ msgstr "Nome (vazio)"
 msgid "Name (Exists)"
 msgstr "Nome (existe)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nunca"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Conta Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Não"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Sem Data Final"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Nenhuma Transação"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Nenhuma Transação Encontrada"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Nenhuma transação corresponde aos filtros especificados."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Notas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Abrir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Abrir Conta"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Page {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Palavra-passe do PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Recibo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Recibos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Data final da recorrência"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Data final da recorrência (inválida)"
 
@@ -539,11 +547,11 @@ msgstr "Data final da recorrência (inválida)"
 msgid "Repeat Interval"
 msgstr "Intervalo de recorrência"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Intervalo de Repetição Alterado"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -565,23 +573,29 @@ msgstr "Selecione a Pasta de Backup"
 msgid "Select Folder"
 msgstr "Selecione a Pasta de Backup"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Organizar por Quantidade"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Organizar por Data"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Organizar por Id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "A senha da conta foi alterada."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "A senha da conta foi removida."
 
@@ -593,7 +607,7 @@ msgstr "A senha será removida ao fechar esta caixa de diálogo."
 msgid "The passwords do not match."
 msgstr "As palavras-passe não coincidem."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -605,15 +619,15 @@ msgstr ""
 "\n"
 "Novas transações recorrentes irão se basear no novo intervalo."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Esta conta não possui dinheiro disponível para transferência."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Esta conta já está aberta."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -628,7 +642,7 @@ msgstr ""
 "Excluir somente a transação de origem permitirá\n"
 "modificar as transações geradas."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -642,120 +656,126 @@ msgstr ""
 "Atualizar somente a transação de origem desassociará\n"
 "as transações geradas da de origem."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transação"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transações"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transações sem grupo"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transferir De {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transferir Para {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Não foi possível exportar conta para o ficheiro."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Não foi possível conectar em sua conta. Senha inserida está incorreta."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Não é possível substituir uma conta aberta."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Não é possível substituir uma conta aberta."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Sem Grupo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Atualizar Apenas Origem"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Atualizar as de origem e as geradas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Atualizar Transação"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Upload"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Visualizar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -765,9 +785,9 @@ msgstr ""
 "\n"
 "Se a palavra-passe for perdida, o PDF ficará inacessível."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Sim"
 
@@ -776,18 +796,18 @@ msgstr "Sim"
 msgid "Your system reported that your currency is"
 msgstr "Seu sistema relatou que sua moeda é"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Bom Dia!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Bom Dia!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -936,68 +956,83 @@ msgstr "Redefinir filtros dos Grupos"
 msgid "Unselect Groups Filters"
 msgstr "Redefinir filtros dos Grupos"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Alternar Visibilidade de Grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Redefinir filtros dos Grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Redefinir filtros dos Grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Calendário"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Selecionar Intervalo"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Início"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "Fim"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Classificar do Primeiro ao Último"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Classificar do Último ao Primeiro"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nova Transação (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Novo"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1011,8 +1046,8 @@ msgid "Color"
 msgstr "Cor"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Remover"
 
@@ -1337,20 +1372,24 @@ msgstr "Usar cor do grupo"
 msgid "Use unique color"
 msgstr "Usar cor específica"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extras"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Gerenciar campos extras da transação."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Insira notas aqui"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Editar Transação"
 

--- a/NickvisionMoney.Shared/Resources/po/pt_BR.po
+++ b/NickvisionMoney.Shared/Resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Cópia)"
 
@@ -28,8 +28,16 @@ msgstr "(Cópia)"
 msgid "{0} from {1}"
 msgstr "{0} de {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +62,58 @@ msgstr "Nenhuma Conta Aberta"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Configurações da Conta"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Tipo de Conta"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Adicionar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Crie uma nova transação ou importe transações de um arquivo."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Adicionar senha ao PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Todos os arquivos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Valor"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Valor (Inválido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +121,7 @@ msgstr ""
 "Tem certeza de que quer excluir este grupo?\n"
 "Esta ação é irreversível."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +129,7 @@ msgstr ""
 "Tem certeza de que quer excluir esta transação?\n"
 "Esta ação é irreversível."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +141,9 @@ msgstr ""
 "Não é possível acessar a pasta selecionada. Verifique as permissões do "
 "Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -144,18 +152,18 @@ msgstr "Cancelar"
 msgid "Change Password"
 msgstr "Alterar Senha"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Corrente"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Moeda"
@@ -193,16 +201,16 @@ msgstr "Símbolo da Moeda (Vazio)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Símbolo da moeda (inválido)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Data"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -225,42 +233,42 @@ msgstr "Separador decimal (vazio)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Separador decimal (inválido)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Excluir as Existentes"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Excluir Grupo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Excluir Somente a de Origem"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Deletar a de Origem e as Geradas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Excluir Transação"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Descrição"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Descrição (Vazia)"
 
@@ -286,13 +294,13 @@ msgstr "Senha da Conta de Destino (Inválida)"
 msgid "Destination Account Password (Required)"
 msgstr "Senha da Conta de Destino (Obrigatória)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Desassociar as Existentes"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -301,50 +309,50 @@ msgstr "Desassociar as Existentes"
 msgid "Expense"
 msgstr "Despesas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exportar para um Arquivo"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Conta exportada para o arquivo com sucesso."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Gerado: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Repositório do GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Boa Tarde!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Olá!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Boa Noite!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grupo"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Nome do Grupo"
 
@@ -362,19 +370,19 @@ msgstr "Separador de grupo"
 msgid "Group Separator (Invalid)"
 msgstr "Separador de grupo (inválido)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -383,22 +391,22 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "Importar de um Arquivo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importar de um Arquivo"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, fuzzy, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "Importada {0} transação do arquivo."
 msgstr[1] "Importada {0} transação do arquivo."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -407,24 +415,24 @@ msgstr[1] "Importada {0} transação do arquivo."
 msgid "Income"
 msgstr "Renda"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Gerencie suas finanças pessoais"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Chat Matrix"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -439,98 +447,98 @@ msgstr "Nome (Vazio)"
 msgid "Name (Exists)"
 msgstr "Nome (Existe)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Nunca"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Conta Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Não"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Sem Data Final"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Não Há Transações"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Nenhuma Transação Encontrada"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Nenhuma transação corresponde aos filtros especificados."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Notas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Abrir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Abrir Conta"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Resumo"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Página {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Senha do PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Recibo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Recibos"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Data Final da Repetição"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Data Final da Repetição (Inválida)"
 
@@ -539,11 +547,11 @@ msgstr "Data Final da Repetição (Inválida)"
 msgid "Repeat Interval"
 msgstr "Intervalo de Repetição"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Intervalo de Repetição Alterado"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -565,23 +573,29 @@ msgstr "Selecione a Pasta de Backup"
 msgid "Select Folder"
 msgstr "Selecione a Pasta de Backup"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Ordenar por Valor"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Ordenar por Data"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Ordenar por Id"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "A senha da conta foi alterada."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "A senha da conta foi removida."
 
@@ -593,7 +607,7 @@ msgstr "A senha será removida ao fechar esta caixa de diálogo."
 msgid "The passwords do not match."
 msgstr "As senhas não coincidem."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -605,15 +619,15 @@ msgstr ""
 "\n"
 "Novas transações repetidas serão geradas baseadas no novo intervalo."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Esta conta não tem dinheiro disponível para transferir."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Esta conta já está aberta."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -628,7 +642,7 @@ msgstr ""
 "Excluir apenas a transação de origem permitirá modificar\n"
 "as transações geradas."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -642,120 +656,126 @@ msgstr ""
 "Atualizar apenas a transação de origem desassociará\n"
 "as transações geradas dela."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Transação"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transações"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Transações sem um grupo"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Transferir de {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Transferir para {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tipo"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Não é possível exportar a conta para um arquivo."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Não é possível entrar na conta. A senha fornecida é inválida."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Não é possível substituir uma conta aberta."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Não é possível substituir uma conta aberta."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Sem grupo"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Atualizar Somente a de Origem"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Atualizar a de Origem e as Geradas"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Atualizar Transação"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Carregar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Abrir"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -765,9 +785,9 @@ msgstr ""
 "\n"
 "Se a senha for perdida, o PDF ficará inacessível."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Sim"
 
@@ -776,18 +796,18 @@ msgstr "Sim"
 msgid "Your system reported that your currency is"
 msgstr "Seu sistema informou que sua moeda é"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Bom Dia!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Boa Noite!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -935,68 +955,83 @@ msgstr "Limpar Filtros de Grupos"
 msgid "Unselect Groups Filters"
 msgstr "Limpar Filtros de Grupos"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Alternar Visibilidade dos Grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Limpar Filtros de Grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Limpar Filtros de Grupos"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Calendário"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Selecionar Intervalo"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Início"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "Final"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Ordenar do Primeiro ao Último"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Ordenar do Último ao Primeiro"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Nova Transação (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Novo"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1010,8 +1045,8 @@ msgid "Color"
 msgstr "Cor"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Excluir"
 
@@ -1335,20 +1370,24 @@ msgstr "Usar cor do grupo"
 msgid "Use unique color"
 msgstr "Usar cor específica"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Extras"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Gerenciar campos extras da transação."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Insira notas aqui"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Editar Transação"
 

--- a/NickvisionMoney.Shared/Resources/po/ru.po
+++ b/NickvisionMoney.Shared/Resources/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-06-29 18:15+0000\n"
 "Last-Translator: Fyodor Sobolev <fyodor-sobolev@protonmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/nickvision-money/"
@@ -16,11 +16,11 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Копия)"
 
@@ -32,8 +32,17 @@ msgstr "(Копия)"
 msgid "{0} from {1}"
 msgstr "{0} в {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -56,58 +65,58 @@ msgstr "Имя счёта (Открыт)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Настройки счёта"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Тип счёта"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Добавить"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Добавьте транзакцию или импортируйте транзакции из файла."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "Зашифровать PDF паролем?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Все файлы"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Сумма"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Сумма (Некорректная)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Применить"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +124,7 @@ msgstr ""
 "Вы уверены, что хотите удалить эту группу?\n"
 "Это действие необратимо."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +132,7 @@ msgstr ""
 "Вы уверены, что хотите удалить эту транзакцию?\n"
 "Это действие необратимо."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +142,9 @@ msgstr "Бизнес"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Невозможно получить доступ к папке, проверьте разрешения Flatpak."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -144,13 +153,13 @@ msgstr "Отмена"
 msgid "Change Password"
 msgstr "Изменить пароль"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Расчётный"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -158,7 +167,7 @@ msgstr ""
 "Соавторы на GitHub ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Валюта"
@@ -196,16 +205,16 @@ msgstr "Символ валюты (Пустой)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Символ валюты (Некорректный)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Дата"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -228,41 +237,41 @@ msgstr "Десятичный разделитель (Пустой)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Десятичный разделитель (Некорректный)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Удалить существующие"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Удалить группу"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Удалить только источник"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Удалить всё"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "Удалить транзакцию"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Описание"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Описание (Пусто)"
 
@@ -288,13 +297,13 @@ msgstr "Пароль целевого счёта (Некорректный)"
 msgid "Destination Account Password (Required)"
 msgstr "Пароль целевого счёта (Требуется)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Отвязать существующие"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -303,50 +312,50 @@ msgstr "Отвязать существующие"
 msgid "Expense"
 msgstr "Расходы"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Экспорт в файл"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Счёт успешно экспортирован в файл."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Файл создан: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "Репозиторий GitHub"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Добрый день!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "Здравствуйте!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Добрый вечер!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Группа"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Имя группы"
 
@@ -364,19 +373,19 @@ msgstr "Разделитель групп разрядов"
 msgid "Group Separator (Invalid)"
 msgstr "Разделитель групп разрядов (Некорректный)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Группы"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Справка"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Номер"
 
@@ -384,13 +393,13 @@ msgstr "Номер"
 msgid "Import from Account"
 msgstr "Импорт из счёта"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Импорт из файла"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
@@ -398,9 +407,9 @@ msgstr[0] "Импортировано {0} транзакция из файла."
 msgstr[1] "Импортировано {0} транзакции из файла."
 msgstr[2] "Импортировано {0} транзакций из файла."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -409,24 +418,24 @@ msgstr[2] "Импортировано {0} транзакций из файла."
 msgid "Income"
 msgstr "Доходы"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Управляйте своими личными финансами"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix Чат"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "Н/Д"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -441,98 +450,98 @@ msgstr "Имя (Пусто)"
 msgid "Name (Exists)"
 msgstr "Имя (Занято)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Никогда"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Счёт Nickvision Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Нет"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Без даты окончания"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Нет транзакций"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Не найдено транзакций"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Нет транзакций, соответствующих заданным фильтрам."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Заметки"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Открыть"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Открыть счёт"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Обзор"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Страница {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "Пароль PDF"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "Пожалуйста, подождите окончания импорта транзакций..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Чек"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Чек (Файл недоступен)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Чеки"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Дата окончания повтора"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Дата окончания повтора (Некорректная)"
 
@@ -541,11 +550,11 @@ msgstr "Дата окончания повтора (Некорректная)"
 msgid "Repeat Interval"
 msgstr "Интервал повтора"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Изменение интервала повтора"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -565,23 +574,29 @@ msgstr "Выбрать папку для резервных копий"
 msgid "Select Folder"
 msgstr "Выбрать папку"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Сортировать по сумме"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Сортировать по дате"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Сортировать по номеру"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Пароль счёта был изменён."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Пароль счёта был удалён."
 
@@ -593,7 +608,7 @@ msgstr "Пароль будет удалён после закрытия это�
 msgid "The passwords do not match."
 msgstr "Пароли не совпадают."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -606,15 +621,15 @@ msgstr ""
 "Новые повторяющиеся транзакции будут сгенерированы с использованием нового "
 "интервала."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "На этом счёте нет средств для перевода."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Этот счёт уже открыт."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -628,7 +643,7 @@ msgstr ""
 "Удаление только источника позволит изменять\n"
 "сгенерированные транзакции индивидуально."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -642,54 +657,54 @@ msgstr ""
 "Применение изменений только к источнику отвяжет\n"
 "от него сгенерированные транзакции."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Сумма"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "Транзакция"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Транзакции"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Транзакции без группы"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Перевод из {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Перевод на {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr "Фёдор Соболев https://github.com/fsobolev"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Тип"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Невозможно экспортировать счёт в файл."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -697,16 +712,16 @@ msgstr ""
 "Невозможно импортировать данные из файла. Убедитесь, что у приложения есть "
 "необходимые разрешения и попробуйте снова."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr "Невозможно импортировать данные из файла. Неподдерживаемый тип файла."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Невозможно открыть счёт. Неправильный пароль."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -714,50 +729,56 @@ msgstr ""
 "Невозможно открыть счёт. Убедитесь, что у приложения есть необходимые "
 "разрешения и попробуйте снова."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr "Невозможно перезаписать существующий счёт."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr "Невозможно перезаписать открытый счёт."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Несгруппированные"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Применить только к источнику"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Применить ко всем"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Изменение транзакции"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Загрузить"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Просмотр"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -767,9 +788,9 @@ msgstr ""
 "\n"
 "Если пароль будет утерян, содержимое файла будет недоступно."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Да"
 
@@ -778,18 +799,18 @@ msgstr "Да"
 msgid "Your system reported that your currency is"
 msgstr "Ваша система сообщила, что ваша валюта"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Доброе утро!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Доброй ночи!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -931,65 +952,80 @@ msgstr "Выбрать все фильтры групп"
 msgid "Unselect Groups Filters"
 msgstr "Снять выделение фильтров групп"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Переключить отображение групп"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Выбрать все фильтры групп"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Снять выделение фильтров групп"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Календарь"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr "Выбрать текущий месяц"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Сбросить на сегодняшний день"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Сегодня"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Выбрать период"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Начало"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Конец"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Далее"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Сортировать от первой к последней"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Сортировать от последней к первой"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Новая транзакция (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Новая"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Предложения"
 
@@ -1003,8 +1039,8 @@ msgid "Color"
 msgstr "Цвет"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Удалить"
 
@@ -1314,20 +1350,24 @@ msgstr "Использовать цвет группы"
 msgid "Use unique color"
 msgstr "Использовать собственный цвет"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Прочее"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "Управление дополнительными данными транзакции."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Введите здесь ваши заметки"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "Редактировать транзакцию"
 

--- a/NickvisionMoney.Shared/Resources/po/sv.po
+++ b/NickvisionMoney.Shared/Resources/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Copy)"
 
@@ -28,8 +28,16 @@ msgstr "(Copy)"
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,73 +62,73 @@ msgstr "Konto"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 #, fuzzy
 msgid "Account Settings"
 msgstr "Inställningar"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 #, fuzzy
 msgid "Account Type"
 msgstr "Konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Add"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Alla filer"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 #, fuzzy
 msgid "Amount"
 msgstr "Konto"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Tillämpa"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -130,9 +138,9 @@ msgstr ""
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -141,18 +149,18 @@ msgstr "Avbryt"
 msgid "Change Password"
 msgstr "Change Password"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr ""
@@ -190,16 +198,16 @@ msgstr ""
 msgid "Currency Symbol (Invalid)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -225,44 +233,44 @@ msgstr "Insert Decimal Separator"
 msgid "Decimal Separator (Invalid)"
 msgstr "Insert Decimal Separator"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 #, fuzzy
 msgid "Delete Existing"
 msgstr "Ny Transaktion"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 #, fuzzy
 msgid "Delete Group"
 msgstr "Ny Grupp"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 #, fuzzy
 msgid "Delete Transaction"
 msgstr "Ny Transaktion"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr ""
 
@@ -290,13 +298,13 @@ msgstr "Destination Account Password (Invalid)"
 msgid "Destination Account Password (Required)"
 msgstr "Destination Account Password (Required)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -305,51 +313,51 @@ msgstr ""
 msgid "Expense"
 msgstr "Kostnad"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Exportera till Fil"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "God Eftermiddag!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "God Dag!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "Go kväll!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 #, fuzzy
 msgid "Group"
 msgstr "Grupper"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 #, fuzzy
 msgid "Group Name"
 msgstr "Grupper"
@@ -368,19 +376,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Grupper"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Hjälp"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr ""
 
@@ -389,22 +397,22 @@ msgstr ""
 msgid "Import from Account"
 msgstr "Importera från Fil"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Importera från Fil"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -413,24 +421,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr "Inkomst"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -445,100 +453,100 @@ msgstr ""
 msgid "Name (Exists)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 #, fuzzy
 msgid "Nickvision Denaro Account"
 msgstr "Inga Senaste Konton"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Nej"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "Inga Transaktioner"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "Hittade Inga Transaktioner"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Öppna"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Öppna ett konto"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Översikt"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 #, fuzzy
 msgid "PDF Password"
 msgstr "Password"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr ""
 
@@ -547,11 +555,11 @@ msgstr ""
 msgid "Repeat Interval"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr ""
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 #, fuzzy
@@ -573,23 +581,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "The password of the account was changed."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "The password of the account was removed."
 
@@ -602,7 +616,7 @@ msgstr "The password will be removed upon closing this dialog."
 msgid "The passwords do not match."
 msgstr "The password of the account was changed."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -610,15 +624,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Detta konto är redan öppet."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -627,7 +641,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -636,133 +650,139 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Total"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 #, fuzzy
 msgid "Transaction"
 msgstr "Transaktioner"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "Transaktioner"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 #, fuzzy
 msgid "Transactions without a group"
 msgstr "Hittade Inga Transaktioner"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, fuzzy, csharp-format
 msgid "Transfer From {0}"
 msgstr "Överför Pengar"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, fuzzy, csharp-format
 msgid "Transfer To {0}"
 msgstr "Överför Pengar"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 #, fuzzy
 msgid "Unable to export account to file."
 msgstr "Kan inte skriva över ett öppet konto."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Kan inte logga in till konto. Tilldelat lösenord är fel."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Kan inte skriva över ett öppet konto."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Kan inte skriva över ett öppet konto."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 #, fuzzy
 msgid "Update Transaction"
 msgstr "Ny Transaktion"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Ja"
 
@@ -771,18 +791,18 @@ msgstr "Ja"
 msgid "Your system reported that your currency is"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "God Morgon!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "God Morgon!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -927,66 +947,78 @@ msgstr ""
 msgid "Unselect Groups Filters"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+msgid "Select All Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+msgid "Unselect Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Ny Transaktion (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "Ny"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1001,8 +1033,8 @@ msgid "Color"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr ""
 
@@ -1317,21 +1349,25 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 #, fuzzy
 msgid "Enter notes here"
 msgstr "Enter password here"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 #, fuzzy
 msgid "Edit Transaction"
 msgstr "Transaktioner"

--- a/NickvisionMoney.Shared/Resources/po/ta.po
+++ b/NickvisionMoney.Shared/Resources/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr ""
 
@@ -29,8 +29,16 @@ msgstr ""
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -52,70 +60,70 @@ msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr ""
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -125,9 +133,9 @@ msgstr ""
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr ""
 
@@ -136,18 +144,18 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr ""
@@ -185,16 +193,16 @@ msgstr ""
 msgid "Currency Symbol (Invalid)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -217,41 +225,41 @@ msgstr ""
 msgid "Decimal Separator (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr ""
 
@@ -277,13 +285,13 @@ msgstr ""
 msgid "Destination Account Password (Required)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -292,50 +300,50 @@ msgstr ""
 msgid "Expense"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr ""
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr ""
 
@@ -353,19 +361,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr ""
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr ""
 
@@ -373,22 +381,22 @@ msgstr ""
 msgid "Import from Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -397,24 +405,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -429,98 +437,98 @@ msgstr ""
 msgid "Name (Exists)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr ""
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr ""
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr ""
 
@@ -529,11 +537,11 @@ msgstr ""
 msgid "Repeat Interval"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr ""
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -553,23 +561,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr ""
 
@@ -581,7 +595,7 @@ msgstr ""
 msgid "The passwords do not match."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -589,15 +603,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -606,7 +620,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -615,127 +629,133 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr ""
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr ""
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr ""
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr ""
 
@@ -744,18 +764,18 @@ msgstr ""
 msgid "Your system reported that your currency is"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -897,65 +917,77 @@ msgstr ""
 msgid "Unselect Groups Filters"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+msgid "Select All Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+msgid "Unselect Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -969,8 +1001,8 @@ msgid "Color"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr ""
 
@@ -1271,20 +1303,24 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr ""
 

--- a/NickvisionMoney.Shared/Resources/po/tr.po
+++ b/NickvisionMoney.Shared/Resources/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-06-11 05:58+0000\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/nickvision-money/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(Kopya)"
 
@@ -31,8 +31,16 @@ msgstr "(Kopya)"
 msgid "{0} from {1}"
 msgstr "{0} / {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -56,58 +64,58 @@ msgstr "Hesap Açılmadı"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "Hesap Ayarları"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "Hesap Türü"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "Ekle"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "Yeni bir işlem ekleyin veya bir dosyadan işlemleri içe aktarın."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "PDFʼye Parola Eklensin mi?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "Tüm dosyalar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "Tutar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "Tutar (Geçersiz)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -115,7 +123,7 @@ msgstr ""
 "Bu grubu silmek istediğinizden emin misiniz?\n"
 "Bu eylem geri alınamaz."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -123,7 +131,7 @@ msgstr ""
 "Bu işlemi silmek istediğinizden emin misiniz?\n"
 "Bu eylem geri alınamaz."
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -133,9 +141,9 @@ msgstr "Kurumsal"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "Seçili klasöre erişilemiyor, Flatpak izinlerini denetleyin."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "İptal Et"
 
@@ -144,13 +152,13 @@ msgstr "İptal Et"
 msgid "Change Password"
 msgstr "Parola Değiştir"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "Çek"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -158,7 +166,7 @@ msgstr ""
 "Contributors on GitHub ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "Para Birimi"
@@ -196,16 +204,16 @@ msgstr "Para Birimi Simgesi (Boş)"
 msgid "Currency Symbol (Invalid)"
 msgstr "Para Birimi Simgesi (Geçersiz)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "Tarih"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -228,41 +236,41 @@ msgstr "Ondalık Ayırıcı (Boş)"
 msgid "Decimal Separator (Invalid)"
 msgstr "Ondalık Ayırıcı (Geçersiz)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "Mevcut Olanı Sil"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "Grubu Sil"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "Yalnızca Kaynağı Sil"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "Kaynağı ve Oluşturulanı Sil"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "İşlemi Sil"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "Açıklama"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "Açıklama (Boş)"
 
@@ -288,13 +296,13 @@ msgstr "Hedef Hesap Parolası (Geçersiz)"
 msgid "Destination Account Password (Required)"
 msgstr "Hedef Hesap Parolası (Gerekli)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Mevcut İlişkiyi Kes"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -303,50 +311,50 @@ msgstr "Mevcut İlişkiyi Kes"
 msgid "Expense"
 msgstr "Gider"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "Dosyaya Dışa Aktar"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "Hesap dosyaya başarıyla dışa aktarıldı."
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "Oluşturuldu: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub Deposu"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "Tünaydın!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "İyi Günler!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "İyi Akşamlar!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "Grup"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "Grup Adı"
 
@@ -364,19 +372,19 @@ msgstr "Grup Ayırıcı"
 msgid "Group Separator (Invalid)"
 msgstr "Grup Ayırıcı (Geçersiz)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "Gruplar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "Yardım"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "Id"
 
@@ -385,22 +393,22 @@ msgstr "Id"
 msgid "Import from Account"
 msgstr "Dosyadan İçe Aktar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "Dosyadan İçe Aktar"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "{0} işlem dosyadan içe aktarıldı."
 msgstr[1] "{0} işlem dosyadan içe aktarıldı."
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -409,24 +417,24 @@ msgstr[1] "{0} işlem dosyadan içe aktarıldı."
 msgid "Income"
 msgstr "Gelir"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "Kişisel mali durumunuzu yönetin"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "Yok"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -441,98 +449,98 @@ msgstr "Ad (Boş)"
 msgid "Name (Exists)"
 msgstr "Ad (Var)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "Asla"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision Denaro Hesabı"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "Hayır"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "Bitiş Tarihi Yok"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "İşlem Yok"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "İşlem Bulunamadı"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "Hiçbir işlem belirtilen süzgeçlerle eşleşmiyor."
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "Notlar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "Aç"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "Hesap Aç"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "Genel Görünüm"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "Sayfa {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "PDF Parolası"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "Makbuz"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "Makbuz (Dosyaya Erişilemez)"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "Makbuzlar"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "Tekrarlama Bitiş Tarihi"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "Tekrarlama Bitiş Tarihi (Geçersiz)"
 
@@ -541,11 +549,11 @@ msgstr "Tekrarlama Bitiş Tarihi (Geçersiz)"
 msgid "Repeat Interval"
 msgstr "Tekrarlama Aralığı"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "Tekrarlama Aralığı Değiştirildi"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -565,23 +573,29 @@ msgstr "Yedekleme Klasörü Seç"
 msgid "Select Folder"
 msgstr "Klasör Seç"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "Tutara Göre Sırala"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "Tarihe Göre Sırala"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "Kimliğe Göre Sırala"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "Hesabın parolası değiştirildi."
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "Hesabın parolası kaldırıldı."
 
@@ -593,7 +607,7 @@ msgstr "Bu iletişim kutusu kapatıldıktan sonra şifre kaldırılacaktır."
 msgid "The passwords do not match."
 msgstr "Parolalar eşleşmiyor."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -605,15 +619,15 @@ msgstr ""
 "\n"
 "Yeni aralık baz alınarak yeni tekrarlama işlemleri oluşturulacaktır."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "Bu hesapta aktarılacak para yok."
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "Bu hesap zaten açıldı."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -628,7 +642,7 @@ msgstr ""
 "Yalnızca kaynak işlemin silinmesi, bireysel olarak oluşturulan işlemlerin "
 "düzenlenebilir olmasını sağlayacaktır."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -642,56 +656,56 @@ msgstr ""
 "Yalnızca kaynak işlemin güncellenmesi, \n"
 "oluşturulan işlemlerin kaynakla ilişkisini kesecektir."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "Toplam"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "İşlem"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "İşlemler"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "Grupsuz işlemler"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "Şuradan Aktar: {0}"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "Şuraya Aktar: {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 "Sabri Ünal <libreajans@gmail.com>\n"
 "Weblate Üstünden Katkı Sağlayan Gönüllüler"
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "Tür"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "Hesap dosyaya dışa aktarılamıyor."
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
@@ -699,16 +713,16 @@ msgstr ""
 "Dosyadan bilgiler içe aktarılamadı. Lütfen uygulamanın dosyaya erişim izni "
 "olduğundan emin olun ve tekrar deneyin."
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr "Dosyadan bilgiler içe aktarılamadı. Desteklenmeyen dosya türü."
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Hesaba giriş yapılamıyor. Sağlanan parola geçersiz."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
@@ -716,52 +730,58 @@ msgstr ""
 "Hesap açılamadı. Uygulamanın dosyaya erişim izni olduğundan emin olun ve "
 "tekrar deneyin."
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "Açılmış bir hesabın üzerine yazılamıyor."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "Açılmış bir hesabın üzerine yazılamıyor."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "Grupsuz"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Yalnızca Kaynağı Güncelle"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Kaynağı ve Oluşturulanı Güncelle"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "İşlemi Güncelle"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Yükle"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "Görünüm"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
@@ -771,9 +791,9 @@ msgstr ""
 "\n"
 "Parola kaybedilirse PDFʼye erişilemez."
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "Evet"
 
@@ -782,18 +802,18 @@ msgstr "Evet"
 msgid "Your system reported that your currency is"
 msgstr "Sisteminiz para biriminizin şu olduğunu bildirdi"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "Günaydın!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "Günaydın!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -937,65 +957,80 @@ msgstr "Tüm Grup Süzgeçlerini Seç"
 msgid "Unselect Groups Filters"
 msgstr "Tüm Grup Süzgeçlerinin Seçimini Kaldır"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "Grupların Görünürlüğünü Değiştir"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "Tüm Grup Süzgeçlerini Seç"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "Tüm Grup Süzgeçlerinin Seçimini Kaldır"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "Takvim"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr "Bugüne Sıfırla"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr "Bugün"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "Aralık Seç"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr "Başlangıç"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr "Bitiş"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr "Sonraki"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "Baştan Sona Sırala"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "Sondan Başa Sırala"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "Yeni İşlem (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 msgctxt "Transaction"
 msgid "New"
 msgstr "Yeni"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr "Öneriler"
 
@@ -1009,8 +1044,8 @@ msgid "Color"
 msgstr "Renk"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Sil"
 
@@ -1324,20 +1359,24 @@ msgstr "Grup rengini kullan"
 msgid "Use unique color"
 msgstr "Benzersiz renk kullan"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr "Ekler"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr "İşlemin ek alanlarını yönetin."
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr "Notları buraya girin"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "İşlemi Düzenle"
 

--- a/NickvisionMoney.Shared/Resources/po/ur.po
+++ b/NickvisionMoney.Shared/Resources/po/ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr ""
 
@@ -28,8 +28,16 @@ msgstr ""
 msgid "{0} from {1}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,73 +62,73 @@ msgstr "میزان"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 #, fuzzy
 msgid "Account Settings"
 msgstr "ترتیبات"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 #, fuzzy
 msgid "Account Type"
 msgstr "میزان"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "شامل کریں"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 #, fuzzy
 msgid "Amount"
 msgstr "میزان"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "لاگو کریں"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
 msgstr ""
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -130,9 +138,9 @@ msgstr ""
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "منسوخ کریں"
 
@@ -141,18 +149,18 @@ msgstr "منسوخ کریں"
 msgid "Change Password"
 msgstr ""
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 msgid "Contributors on GitHub ❤️"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr ""
@@ -190,16 +198,16 @@ msgstr ""
 msgid "Currency Symbol (Invalid)"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -222,41 +230,41 @@ msgstr ""
 msgid "Decimal Separator (Invalid)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr ""
 
@@ -282,13 +290,13 @@ msgstr ""
 msgid "Destination Account Password (Required)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr ""
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -297,50 +305,50 @@ msgstr ""
 msgid "Expense"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "گٹہب ریپو"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr ""
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr ""
 
@@ -358,19 +366,19 @@ msgstr ""
 msgid "Group Separator (Invalid)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "مدد"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr ""
 
@@ -378,22 +386,22 @@ msgstr ""
 msgid "Import from Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -402,24 +410,24 @@ msgstr[1] ""
 msgid "Income"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "ذاتی مالیات کا منتظم"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "میٹرکس چیٹ"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr ""
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -434,99 +442,99 @@ msgstr ""
 msgid "Name (Exists)"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "نہیں"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr ""
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "کھولیں"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 #, fuzzy
 msgid "Open Account"
 msgstr "میزان"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr ""
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr ""
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr ""
 
@@ -535,11 +543,11 @@ msgstr ""
 msgid "Repeat Interval"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr ""
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 #, fuzzy
@@ -561,23 +569,29 @@ msgstr ""
 msgid "Select Folder"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr ""
 
@@ -589,7 +603,7 @@ msgstr ""
 msgid "The passwords do not match."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -597,15 +611,15 @@ msgid ""
 "New repeat transactions will be generated based off the new interval."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -614,7 +628,7 @@ msgid ""
 "generated transactions to be modifiable."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -623,127 +637,133 @@ msgid ""
 "generated transactions from the source."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr ""
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr ""
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 msgid "Unable to overwrite an existing account."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 msgid "Unable to overwrite an opened account."
 msgstr ""
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "ہاں"
 
@@ -752,18 +772,18 @@ msgstr "ہاں"
 msgid "Your system reported that your currency is"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -906,66 +926,78 @@ msgstr ""
 msgid "Unselect Groups Filters"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+msgid "Toggle Tags Visibility"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+msgid "Select All Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+msgid "Unselect Tags Filters"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 msgctxt "DateRange"
 msgid "Start"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 msgctxt "DateRange"
 msgid "End"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "نیا"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -980,8 +1012,8 @@ msgid "Color"
 msgstr ""
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr ""
 
@@ -1287,20 +1319,24 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 msgid "Enter notes here"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr ""
 

--- a/NickvisionMoney.Shared/Resources/po/zh.po
+++ b/NickvisionMoney.Shared/Resources/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-07 20:27-0400\n"
+"POT-Creation-Date: 2023-08-10 15:41-0400\n"
 "PO-Revision-Date: 2023-07-29 12:14+0000\n"
 "Last-Translator: Yuxin Ren <yx_Ren2018@outlook.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: ../../../Controllers/AccountViewController.cs:529
+#: ../../../Controllers/AccountViewController.cs:566
 msgid "(Copy)"
 msgstr "(复制)"
 
@@ -31,8 +31,15 @@ msgstr "(复制)"
 msgid "{0} from {1}"
 msgstr "{0} 从 {1}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:407
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1188
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:629
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:635
+#, csharp-format
+msgid "{0} tag"
+msgid_plural "{0} tags"
+msgstr[0] ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:447
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1289
 #, fuzzy, csharp-format
 msgid "{0} transaction"
 msgid_plural "{0} transactions"
@@ -54,58 +61,58 @@ msgstr "账户名称(已启用)"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:69
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:445
-#: ../../../Models/Account.cs:1641
+#: ../../../Models/Account.cs:1704
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:35
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:30
 msgid "Account Settings"
 msgstr "账户设置"
 
-#: ../../../Models/Account.cs:1642
+#: ../../../Models/Account.cs:1705
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:59
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:148
 msgid "Account Type"
 msgstr "账户类型"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/new_password_dialog.blp:46
 msgid "Add"
 msgstr "添加"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:428
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:469
 msgid "Add a new transaction or import transactions from a file."
 msgstr "添加交易或从文件中导入交易。"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid "Add Password To PDF?"
 msgstr "添加密码至PDF?"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:653
 #: ../../../../NickvisionMoney.GNOME/Views/NewAccountDialog.cs:392
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:600
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:670
 msgid "All files"
 msgstr "所有文件"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:481
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:141
-#: ../../../Models/Account.cs:1675 ../../../Models/Account.cs:1709
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:489
+#: ../../../Models/Account.cs:1738 ../../../Models/Account.cs:1774
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:76
 #: NickvisionMoney.GNOME/Blueprints/transfer_dialog.blp:75
 msgid "Amount"
 msgstr "金额"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:500
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:176
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:508
 msgid "Amount (Invalid)"
 msgstr "金额 (无效)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:171
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:108
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:180
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:129
 msgid "Apply"
 msgstr "应用"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid ""
 "Are you sure you want to delete this group?\n"
 "This action is irreversible."
@@ -113,7 +120,7 @@ msgstr ""
 "是否确认删除此组？\n"
 "该操作不可逆。"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid ""
 "Are you sure you want to delete this transaction?\n"
 "This action is irreversible."
@@ -121,7 +128,7 @@ msgstr ""
 "確認刪除交易?\n"
 "此操作不可逆轉。"
 
-#: ../../../Models/Account.cs:1649
+#: ../../../Models/Account.cs:1712
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Business"
@@ -131,9 +138,9 @@ msgstr "商务"
 msgid "Can't access the selected folder, check Flatpak permissions."
 msgstr "没有所选文件夹的权限，请检查Flatpak权限。"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:797
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:829
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:862
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:889
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:921
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:954
 msgid "Cancel"
 msgstr "取消"
 
@@ -142,13 +149,13 @@ msgstr "取消"
 msgid "Change Password"
 msgstr "更改密码"
 
-#: ../../../Models/Account.cs:1647
+#: ../../../Models/Account.cs:1710
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Checking"
 msgstr "支票"
 
-#: ../../../Controllers/MainWindowController.cs:93
+#: ../../../Controllers/MainWindowController.cs:106
 #, fuzzy
 msgid "Contributors on GitHub ❤️"
 msgstr ""
@@ -156,7 +163,7 @@ msgstr ""
 "GitHub 贡献者 ❤️ {1}"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:106
-#: ../../../Models/Account.cs:1643
+#: ../../../Models/Account.cs:1706
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:89
 msgid "Currency"
 msgstr "货币"
@@ -194,16 +201,16 @@ msgstr "货币符号 (空)"
 msgid "Currency Symbol (Invalid)"
 msgstr "货币符号 (无效)"
 
-#: ../../../Controllers/MainWindowController.cs:96
+#: ../../../Controllers/MainWindowController.cs:109
 msgid "DaPigGuy"
 msgstr ""
 
-#: ../../../Models/Account.cs:1704
+#: ../../../Models/Account.cs:1768
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:110
 msgid "Date"
 msgstr "日期"
 
-#: ../../../Controllers/MainWindowController.cs:97
+#: ../../../Controllers/MainWindowController.cs:110
 msgid "David Lapshin"
 msgstr ""
 
@@ -226,41 +233,41 @@ msgstr "小数点分隔符 (空)"
 msgid "Decimal Separator (Invalid)"
 msgstr "小数点分隔符 (无效)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:801
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:893
 msgid "Delete Existing"
 msgstr "删除已存在的"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:956
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1048
 msgid "Delete Group"
 msgstr "删除组"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:865
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:957
 msgid "Delete Only Source"
 msgstr "删除唯一源"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:866
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
 msgid "Delete Source and Generated"
 msgstr "删除源和内容"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:886
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:978
 msgid "Delete Transaction"
 msgstr "删除交易"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:4
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:6
 msgid "Denaro"
 msgstr "Denaro"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:479
-#: ../../../Models/Account.cs:1674 ../../../Models/Account.cs:1705
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:487
+#: ../../../Models/Account.cs:1737 ../../../Models/Account.cs:1769
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:39
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:65
 msgid "Description"
 msgstr "描述"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:495
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:503
 msgid "Description (Empty)"
 msgstr "描述 (空)"
 
@@ -286,13 +293,13 @@ msgstr "目标账户密码 (无效)"
 msgid "Destination Account Password (Required)"
 msgstr "目标账户密码 (必要)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:800
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:892
 msgid "Disassociate Existing"
 msgstr "Disassociate Existing"
 
-#: ../../../Models/Account.cs:1627 ../../../Models/Account.cs:1755
-#: ../../../Models/Account.cs:1872 ../../../Models/Account.cs:1904
-#: ../../../Models/Account.cs:1959 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1690 ../../../Models/Account.cs:1820
+#: ../../../Models/Account.cs:1938 ../../../Models/Account.cs:1970
+#: ../../../Models/Account.cs:2025 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:111
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:47
@@ -301,50 +308,50 @@ msgstr "Disassociate Existing"
 msgid "Expense"
 msgstr "支出"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:645
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:672
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:737
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:764
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:11
 msgid "Export to File"
 msgstr "导出到文件"
 
-#: ../../../Controllers/AccountViewController.cs:971
-#: ../../../Controllers/AccountViewController.cs:989
+#: ../../../Controllers/AccountViewController.cs:1032
+#: ../../../Controllers/AccountViewController.cs:1050
 msgid "Exported account to file successfully."
 msgstr "成功将账户导出到文件。"
 
-#: ../../../Controllers/MainWindowController.cs:95
+#: ../../../Controllers/MainWindowController.cs:108
 msgid "Fyodor Sobolev"
 msgstr ""
 
-#: ../../../Models/Account.cs:1592
+#: ../../../Models/Account.cs:1655
 #, csharp-format
 msgid "Generated: {0}"
 msgstr "已生成: {0}"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:487
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:489
 msgid "GitHub Repo"
 msgstr "GitHub Repo"
 
-#: ../../../Controllers/MainWindowController.cs:130
+#: ../../../Controllers/MainWindowController.cs:143
 msgid "Good Afternoon!"
 msgstr "下午好!"
 
-#: ../../../Controllers/MainWindowController.cs:132
+#: ../../../Controllers/MainWindowController.cs:145
 msgid "Good Day!"
 msgstr "祝你有美好的一天!"
 
-#: ../../../Controllers/MainWindowController.cs:131
+#: ../../../Controllers/MainWindowController.cs:144
 msgid "Good Evening!"
 msgstr "晚上好!"
 
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:59
-#: ../../../Controllers/TransactionDialogController.cs:208
+#: ../../../Controllers/TransactionDialogController.cs:218
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:47
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:174
 msgid "Group"
 msgstr "群组"
 
-#: ../../../Models/Account.cs:1707
+#: ../../../Models/Account.cs:1771
 msgid "Group Name"
 msgstr "组名"
 
@@ -362,19 +369,19 @@ msgstr "组别分隔符"
 msgid "Group Separator (Invalid)"
 msgstr "组别分隔符 (无效)"
 
-#: ../../../Models/Account.cs:1672
+#: ../../../Models/Account.cs:1735
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:133
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:76
 msgid "Groups"
 msgstr "群组"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:202
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:203
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:79
 #: NickvisionMoney.GNOME/Blueprints/window.blp:7
 msgid "Help"
 msgstr "帮助"
 
-#: ../../../Models/Account.cs:1703 ../../../Models/Account.cs:1774
+#: ../../../Models/Account.cs:1767 ../../../Models/Account.cs:1840
 msgid "Id"
 msgstr "ID"
 
@@ -382,21 +389,21 @@ msgstr "ID"
 msgid "Import from Account"
 msgstr "从账户导入"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:598
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:690
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:8
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:41
 msgid "Import from File"
 msgstr "从文件导入"
 
-#: ../../../Controllers/AccountViewController.cs:954
+#: ../../../Controllers/AccountViewController.cs:1015
 #, csharp-format
 msgid "Imported {0} transaction from file."
 msgid_plural "Imported {0} transactions from file."
 msgstr[0] "从文件导入 {0} 笔交易"
 
-#: ../../../Models/Account.cs:1625 ../../../Models/Account.cs:1754
-#: ../../../Models/Account.cs:1871 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1958 ../../../Models/Account.cs:2031
+#: ../../../Models/Account.cs:1688 ../../../Models/Account.cs:1819
+#: ../../../Models/Account.cs:1937 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:2024 ../../../Models/Account.cs:2097
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:75
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:90
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:33
@@ -405,24 +412,24 @@ msgstr[0] "从文件导入 {0} 笔交易"
 msgid "Income"
 msgstr "收入"
 
-#: ../../../Controllers/MainWindowController.cs:73
+#: ../../../Controllers/MainWindowController.cs:86
 #: NickvisionMoney.Shared/org.nickvision.money.desktop.in:5
 #: NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in:8
 msgid "Manage your personal finances"
 msgstr "管理你的个人财务"
 
-#: ../../../Controllers/MainWindowController.cs:91
+#: ../../../Controllers/MainWindowController.cs:104
 msgid "Matrix Chat"
 msgstr "Matrix Chat"
 
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:185
-#: ../../../Models/Account.cs:1398 ../../../Models/Account.cs:1453
+#: ../../../Models/Account.cs:1460 ../../../Models/Account.cs:1515
 msgid "N/A"
 msgstr "N/A"
 
 #: ../../../../NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs:329
 #: ../../../../NickvisionMoney.GNOME/Views/GroupDialog.cs:146
-#: ../../../Models/Account.cs:1673
+#: ../../../Models/Account.cs:1736
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:54
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:33
 msgid "Name"
@@ -437,98 +444,98 @@ msgstr "名称 (空)"
 msgid "Name (Exists)"
 msgstr "名称 (已存在)"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:581
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:569
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:165
 msgid "Never"
 msgstr "永不"
 
-#: ../../../Controllers/MainWindowController.cs:92
-#: ../../../Controllers/MainWindowController.cs:94
+#: ../../../Controllers/MainWindowController.cs:105
+#: ../../../Controllers/MainWindowController.cs:107
 msgid "Nicholas Logozzo"
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: ../../../../NickvisionMoney.GNOME/Views/TransferDialog.cs:205
-#: ../../../Models/Account.cs:1803
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:330
+#: ../../../Models/Account.cs:1869
 msgid "Nickvision Denaro Account"
 msgstr "Nickvision的Denaro账户"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:689
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:888
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:958
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:781
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:980
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1050
 msgid "No"
 msgstr "否"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:397
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:468
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:613
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:403
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:475
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:601
 msgid "No End Date"
 msgstr "没有结束日期"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:468
 msgid "No Transactions"
 msgstr "没有交易"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:418
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:459
 msgid "No Transactions Found"
 msgstr "没有找到交易"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:419
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:460
 msgid "No transactions match the specified filters."
 msgstr "没有符合条件的交易"
 
-#: ../../../Models/Account.cs:1708
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:314
+#: ../../../Models/Account.cs:1773
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:364
 msgid "Notes"
 msgstr "注释"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:209
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:210
 msgid "Open"
 msgstr "开启"
 
-#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:326
+#: ../../../../NickvisionMoney.GNOME/Views/MainWindow.cs:328
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:22
 #: NickvisionMoney.GNOME/Blueprints/window.blp:208
 msgid "Open Account"
 msgstr "开设账户"
 
-#: ../../../Models/Account.cs:1603
+#: ../../../Models/Account.cs:1666
 msgid "Overview"
 msgstr "概要"
 
-#: ../../../Models/Account.cs:1806
+#: ../../../Models/Account.cs:1872
 msgid "Page {0}"
 msgstr "第 {0} 页"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:699
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:791
 msgid "PDF Password"
 msgstr "PDF 密码"
 
-#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:300
 msgid "Please wait while transactions import..."
 msgstr "正在导入交易，请稍候..."
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:485
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:651
-#: ../../../Models/Account.cs:1775
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:270
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:493
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:668
+#: ../../../Models/Account.cs:1841
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:320
 msgid "Receipt"
 msgstr "收据"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:511
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:519
 msgid "Receipt (File Inaccessible)"
 msgstr "收据（文件无法访问）"
 
-#: ../../../Models/Account.cs:1773
+#: ../../../Models/Account.cs:1839
 msgid "Receipts"
 msgstr "收据"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:483
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:491
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:136
 msgid "Repeat End Date"
 msgstr "重复结束日期"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:505
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:513
 msgid "Repeat End Date (Invalid)"
 msgstr "重复结束日期（无效）"
 
@@ -537,11 +544,11 @@ msgstr "重复结束日期（无效）"
 msgid "Repeat Interval"
 msgstr "重复间隔"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid "Repeat Interval Changed"
 msgstr "重复间隔已更改"
 
-#: ../../../Models/Account.cs:1648
+#: ../../../Models/Account.cs:1711
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:62
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:152
 msgid "Savings"
@@ -561,23 +568,29 @@ msgstr "选择备份文件夹"
 msgid "Select Folder"
 msgstr "选择文件夹"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Amount"
 msgstr "按金额排序"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Date"
 msgstr "按日期排序"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:225
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:256
 msgid "Sort By Id"
 msgstr "按 ID 排序"
 
-#: ../../../Controllers/AccountViewController.cs:601
+#: ../../../Models/Account.cs:1772
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:200
+msgid "Tags"
+msgstr ""
+
+#: ../../../Controllers/AccountViewController.cs:638
 msgid "The password of the account was changed."
 msgstr "账户密码已更改。"
 
-#: ../../../Controllers/AccountViewController.cs:597
+#: ../../../Controllers/AccountViewController.cs:634
 msgid "The password of the account was removed."
 msgstr "账户密码已被删除。"
 
@@ -589,7 +602,7 @@ msgstr "关闭此对话框后，密码将被删除。"
 msgid "The passwords do not match."
 msgstr "密码不匹配。"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:795
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:887
 msgid ""
 "The repeat interval was changed.\n"
 "What would you like to do with existing generated transactions?\n"
@@ -601,15 +614,15 @@ msgstr ""
 "\n"
 "新的重复交易将是使用新的间隔。"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:586
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:678
 msgid "This account has no money available to transfer."
 msgstr "该账户没有足够资金完成转账。"
 
-#: ../../../Controllers/MainWindowController.cs:339
+#: ../../../Controllers/MainWindowController.cs:352
 msgid "This account is already opened."
 msgstr "此账户已经开启"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:860
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:952
 #, fuzzy
 msgid ""
 "This transaction is a source repeat transaction.\n"
@@ -623,7 +636,7 @@ msgstr ""
 "\n"
 "只删去此源交易，将允许后续生成的交易的更改。"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid ""
 "This transaction is a source repeat transaction.\n"
 "What would you like to do with the repeat transactions?\n"
@@ -637,129 +650,135 @@ msgstr ""
 "Updating only the source transaction will disassociate\n"
 "generated transactions from the source."
 
-#: ../../../Controllers/MainWindowController.cs:98
+#: ../../../Controllers/MainWindowController.cs:111
 msgid "Tobias Bernard"
 msgstr ""
 
-#: ../../../Models/Account.cs:1622
+#: ../../../Models/Account.cs:1685
 #: NickvisionMoney.GNOME/Blueprints/account_view.blp:79
 #: NickvisionMoney.GNOME/Blueprints/dashboard_view.blp:61
 msgid "Total"
 msgstr "總額"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:157
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:166
 #: NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp:56
 msgid "Transaction"
 msgstr "交易"
 
-#: ../../../Models/Account.cs:1702
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:370
+#: ../../../Models/Account.cs:1766
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:416
 msgid "Transactions"
 msgstr "交易"
 
-#: ../../../Models/Account.cs:476
+#: ../../../Models/Account.cs:497
 msgid "Transactions without a group"
 msgstr "暫無組群之交易"
 
-#: ../../../Controllers/AccountViewController.cs:899
+#: ../../../Controllers/AccountViewController.cs:960
 #, csharp-format
 msgid "Transfer From {0}"
 msgstr "從 {0} 轉帳"
 
-#: ../../../Controllers/AccountViewController.cs:871
+#: ../../../Controllers/AccountViewController.cs:932
 #, csharp-format
 msgid "Transfer To {0}"
 msgstr "轉帳到 {0}"
 
-#: ../../../Controllers/MainWindowController.cs:99
+#: ../../../Controllers/MainWindowController.cs:112
 msgid "translator-credits"
 msgstr ""
 
-#: ../../../Models/Account.cs:1706
+#: ../../../Models/Account.cs:1770
 msgid "Type"
 msgstr "種類"
 
-#: ../../../Controllers/AccountViewController.cs:975
-#: ../../../Controllers/AccountViewController.cs:993
+#: ../../../Controllers/AccountViewController.cs:1036
+#: ../../../Controllers/AccountViewController.cs:1054
 msgid "Unable to export account to file."
 msgstr "無法導出帳戶"
 
-#: ../../../Controllers/AccountViewController.cs:933
+#: ../../../Controllers/AccountViewController.cs:994
 msgid ""
 "Unable to import information from the file. Please ensure that the app has "
 "permissions to access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/AccountViewController.cs:958
+#: ../../../Controllers/AccountViewController.cs:1019
 msgid "Unable to import information from the file. Unsupported file type."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:321
+#: ../../../Controllers/MainWindowController.cs:334
 msgid "Unable to login to account. Provided password is invalid."
 msgstr "Unable to login to account. Provided password is invalid."
 
-#: ../../../Controllers/MainWindowController.cs:274
-#: ../../../Controllers/MainWindowController.cs:328
+#: ../../../Controllers/MainWindowController.cs:287
+#: ../../../Controllers/MainWindowController.cs:341
 msgid ""
 "Unable to open the account. Please ensure that the app has permissions to "
 "access the file and try again."
 msgstr ""
 
-#: ../../../Controllers/MainWindowController.cs:262
+#: ../../../Controllers/MainWindowController.cs:275
 #, fuzzy
 msgid "Unable to overwrite an existing account."
 msgstr "無法淩駕已開啟的帳戶."
 
-#: ../../../Controllers/MainWindowController.cs:251
+#: ../../../Controllers/MainWindowController.cs:264
 #, fuzzy
 msgid "Unable to overwrite an opened account."
 msgstr "無法淩駕已開啟的帳戶."
 
-#: ../../../Controllers/TransactionDialogController.cs:89
-#: ../../../Controllers/TransactionDialogController.cs:331
-#: ../../../Controllers/AccountViewController.cs:479
-#: ../../../Controllers/AccountViewController.cs:825
-#: ../../../Models/Account.cs:475 ../../../Models/Account.cs:1678
-#: ../../../Models/Account.cs:1758 ../../../Models/Account.cs:1903
-#: ../../../Models/Account.cs:1904 ../../../Models/Account.cs:1908
-#: ../../../Models/Account.cs:1998
+#: ../../../Controllers/TransactionDialogController.cs:93
+#: ../../../Controllers/TransactionDialogController.cs:342
+#: ../../../Controllers/AccountViewController.cs:510
+#: ../../../Controllers/AccountViewController.cs:886
+#: ../../../Models/Account.cs:496 ../../../Models/Account.cs:1741
+#: ../../../Models/Account.cs:1823 ../../../Models/Account.cs:1969
+#: ../../../Models/Account.cs:1970 ../../../Models/Account.cs:1974
+#: ../../../Models/Account.cs:2064
 msgid "Ungrouped"
 msgstr "無組群"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:832
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:170
+#: ../../../Controllers/AccountViewController.cs:1190
+#: ../../../Models/Account.cs:109
+msgid "Untagged"
+msgstr ""
+
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:924
 msgid "Update Only Source"
 msgstr "Update Only Source"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:833
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:925
 msgid "Update Source and Generated"
 msgstr "Update Source and Generated"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:827
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:919
 msgid "Update Transaction"
 msgstr "Update Transaction"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:420
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:639
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:301
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:427
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:656
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:351
 msgid "Upload"
 msgstr "Upload"
 
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:416
-#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:680
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:279
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:423
+#: ../../../../NickvisionMoney.GNOME/Views/TransactionDialog.cs:697
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:329
 msgid "View"
 msgstr "View"
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:687
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:779
 msgid ""
 "Would you like to password-protect the PDF file?\n"
 "\n"
 "If the password is lost, the PDF will be inaccessible."
 msgstr ""
 
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:692
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:891
-#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:961
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:784
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:983
+#: ../../../../NickvisionMoney.GNOME/Views/AccountView.cs:1053
 msgid "Yes"
 msgstr "是"
 
@@ -768,18 +787,18 @@ msgstr "是"
 msgid "Your system reported that your currency is"
 msgstr "Your system reported that your currency is"
 
-#: ../../../Controllers/MainWindowController.cs:129
+#: ../../../Controllers/MainWindowController.cs:142
 msgctxt "Morning"
 msgid "Good Morning!"
 msgstr "日安!"
 
-#: ../../../Controllers/MainWindowController.cs:128
+#: ../../../Controllers/MainWindowController.cs:141
 msgctxt "Night"
 msgid "Good Morning!"
 msgstr "晚上好!"
 
 #: NickvisionMoney.GNOME/Blueprints/account_settings_dialog.blp:22
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:317
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:358
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:25
 #: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:21
 msgid "Back"
@@ -926,68 +945,83 @@ msgstr "重置組群篩選條件"
 msgid "Unselect Groups Filters"
 msgstr "重置組群篩選條件"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:177
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:180
+#, fuzzy
+msgid "Toggle Tags Visibility"
+msgstr "切換組群可見性"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:188
+#, fuzzy
+msgid "Select All Tags Filters"
+msgstr "重置組群篩選條件"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:195
+#, fuzzy
+msgid "Unselect Tags Filters"
+msgstr "重置組群篩選條件"
+
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:218
 msgid "Calendar"
 msgstr "日曆"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:183
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:224
 msgid "Select Current Month"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:189
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:230
 msgid "Reset To Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:192
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:233
 msgid "Today"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:209
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:250
 msgid "Select Range"
 msgstr "選擇範圍"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:214
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:255
 #, fuzzy
 msgctxt "DateRange"
 msgid "Start"
 msgstr "開始"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:239
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:280
 #, fuzzy
 msgctxt "DateRange"
 msgid "End"
 msgstr "結束"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:307
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:348
 msgid "Visualize"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:325
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:366
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:122
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:181
 #: NickvisionMoney.GNOME/Blueprints/new_account_dialog.blp:269
 msgid "Next"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:387
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:432
 msgid "Sort From First To Last"
 msgstr "排序: 從最新到最後"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:393
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:438
 msgid "Sort From Last To First"
 msgstr "排序: 從最後到最新"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:423
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:470
 msgid "New Transaction (Ctrl+Shift+N)"
 msgstr "新增交易 (Ctrl+Shift+N)"
 
-#: NickvisionMoney.GNOME/Blueprints/account_view.blp:431
+#: NickvisionMoney.GNOME/Blueprints/account_view.blp:478
 #, fuzzy
 msgctxt "Transaction"
 msgid "New"
 msgstr "新增"
 
-#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:13
+#: NickvisionMoney.GNOME/Blueprints/autocomplete_box.blp:15
 msgid "Suggestions"
 msgstr ""
 
@@ -1002,8 +1036,8 @@ msgid "Color"
 msgstr "顏色"
 
 #: NickvisionMoney.GNOME/Blueprints/group_dialog.blp:65
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:290
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:287
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:340
 msgid "Delete"
 msgstr "Delete"
 
@@ -1321,21 +1355,25 @@ msgstr ""
 msgid "Use unique color"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:204
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:262
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:237
+msgid "Add Tag"
+msgstr ""
+
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:254
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:312
 msgid "Extras"
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:205
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:255
 msgid "Manage extra fields of the transaction."
 msgstr ""
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:315
+#: NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp:365
 #, fuzzy
 msgid "Enter notes here"
 msgstr "請在此輸入名稱"
 
-#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:30
+#: NickvisionMoney.GNOME/Blueprints/transaction_row.blp:31
 msgid "Edit Transaction"
 msgstr "編輯交易資料"
 

--- a/NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in
+++ b/NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in
@@ -50,6 +50,7 @@
     <release version="2023.8.0-beta2" date="2023-08-08">
       <description translatable="no">
         <p>- Added graph visuals to the Account view as well as in exported PDFs</p>
+        <p>- Added tags that can be added to transactions for better management and filtering</p>
         <p>- Added the option to select the entire current month as the date range filter </p>
         <p>- Improved the transaction description suggestion algorithm with fuzzy search</p>
         <p>- Fixed an issue where the help button in the import toast was not working</p>


### PR DESCRIPTION
Closes #101 

Tags are strings meant to be used as additional filtering method. A transaction can have as many tags as the user wants. Tags are only stored in transactions, list of tags in an account is generated on loading transactions; as result, there's no need to remove tags - unused ones automatically disappear on the account closing. Tags can contain any characters except `,` because it's used as separator.
`Gtk.ScrolledWindow` with fixed size is used because `propagate-natural-height` doesn't work in a popover, and I didn't find a better way to create tags managing interface without sacrificing usability. It has `card` style class because we need to visually separate it from Add tag entry/button, separator doesn't work here because elements a child of a popover always have margins. Tags are just `Gtk.ToggleButton`s without any additional styling (I tried to make them more rounded first, but I think they looked worse).

Implemented: adding, selecting, loading and saving tags in transactions, as well as exporting/importing tags.

TODO:
- [x] Filtering using tags
- [x] Show/hide tags
- [x] Update po(t)
- [x] Update docs

Unrelated, but I wish to implement in the same PR since I already start polishing some things:
- [x] Saving graphs state (visible/hidden)