### PR TITLE
The source amount is multiplied by the ratio, not divided.

### DIFF
--- a/NickvisionMoney.Shared/Models/CurrencyConversionService.cs
+++ b/NickvisionMoney.Shared/Models/CurrencyConversionService.cs
@@ -33,7 +33,7 @@ public class CurrencyConversion
     /// <summary>
     /// The result amount
     /// </summary>
-    public decimal ResultAmount => SourceAmount / ConversionRate;
+    public decimal ResultAmount => SourceAmount * ConversionRate;
     
     /// <summary>
     /// Constructs a CurrencyConversion


### PR DESCRIPTION
Fixes #701