### PR TITLE
Shared.Tests - Add Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
   contents: read
 jobs:
-  aura:
+  shared:
     name: "Test NickvisionMoney.Shared"
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    types: [ "review_requested", "ready_for_review" ]
+  workflow_dispatch:
+name: Tests
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  aura:
+    name: "Test NickvisionMoney.Shared"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '7.0.x' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Install dependencies
+        run: dotnet restore NickvisionMoney.Shared/NickvisionMoney.Shared.csproj
+      - name: Build
+        run: dotnet build NickvisionMoney.Shared/NickvisionMoney.Shared.csproj --configuration Release --no-restore
+      - name: Test
+        run: dotnet test NickvisionMoney.Shared.Tests/NickvisionMoney.Shared.Tests.csproj --verbosity normal

--- a/NickvisionMoney.GNOME/Blueprints/group_dialog.blp
+++ b/NickvisionMoney.GNOME/Blueprints/group_dialog.blp
@@ -6,7 +6,6 @@ Adw.Window _root {
   modal: true;
   resizable: false;
   default-widget: _applyButton;
-  hide-on-close: true;
 
   content: Gtk.Box {
     orientation: vertical;

--- a/NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp
+++ b/NickvisionMoney.GNOME/Blueprints/shortcuts_dialog.blp
@@ -7,8 +7,7 @@ Gtk.ShortcutsWindow _root {
   modal: true;
   resizable: true;
   destroy-with-parent: false;
-  hide-on-close: true;
-
+  
   Gtk.ShortcutsSection {
     Gtk.ShortcutsGroup {
       title: _("Account");

--- a/NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp
+++ b/NickvisionMoney.GNOME/Blueprints/transaction_dialog.blp
@@ -5,7 +5,6 @@ Adw.Window _root {
   default-width: 450;
   resizable: false;
   modal: true;
-  hide-on-close: true;
 
   content: Gtk.Box {
     orientation: vertical;

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -46,6 +46,7 @@ public partial class Program
             @"* Fixed an issue where the currency conversion service would provide the wrong conversion rate
               * Fixed an issue where small converted currency amounts would show as 0
               * Improved UX in Currency Converter dialog
+              * Fixed incorrect display of amounts for locales that use Cape Verdean escudo as currency
               * Updated and added translations (Thanks to everyone on Weblate)!";
         _application.OnActivate += OnActivate;
         if (File.Exists(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) + "/org.nickvision.money.gresource"))

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -1,0 +1,120 @@
+using System.Globalization;
+using NickvisionMoney.Shared.Helpers;
+using Xunit;
+
+namespace NickvisionMoney.Shared.Tests;
+
+public class CurrencyHelperTests
+{
+    public static decimal[] SampleAmounts = { 0M, 109M, 100M, 10920M, 0.002M, 1.2M, 12.00000004M, 1.0234567890M };
+
+    public static IEnumerable<object[]> GetSampleData()
+    {
+        var cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures).AsEnumerable();
+        //Add a custom culture
+        var goldCulture = CultureInfo.InvariantCulture.Clone() as CultureInfo;
+        goldCulture!.NumberFormat.CurrencyDecimalDigits = 99;
+        goldCulture.NumberFormat.CurrencyDecimalSeparator = "*";
+        goldCulture.NumberFormat.CurrencyGroupSeparator = "/";
+        goldCulture.NumberFormat.CurrencySymbol = "\ud83e\ude99";
+        cultures = cultures.Append(goldCulture);
+        foreach (var culture in cultures)
+        {
+            foreach (var number in SampleAmounts)
+            {
+                yield return new object[] { culture, number };
+            }
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(GetSampleData))]
+    public void ToAmountString_AllCulturesShouldWorkByDefault(CultureInfo culture, decimal amount)
+    {
+        var expected = amount.ToString("C", culture);
+        if (culture.NumberFormat.CurrencyDecimalDigits == 99 && expected.Contains(culture.NumberFormat.CurrencyDecimalSeparator))
+        {
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+                expected = expected.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
+        }
+        var result = amount.ToAmountString(culture, false);
+        Assert.Equal(expected, result);
+    }
+    
+    [Theory]
+    [MemberData(nameof(GetSampleData))]
+    public void ToAmountString_AllCulturesShouldWorkWithNativeDigits(CultureInfo culture, decimal amount)
+    {
+        var expected = amount.ToString("C", culture);
+        if (culture.NumberFormat.CurrencyDecimalDigits == 99 && expected.Contains(culture.NumberFormat.CurrencyDecimalSeparator))
+        {
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+                expected = expected.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
+        }
+        expected =  expected
+            .Replace("0", culture.NumberFormat.NativeDigits[0])
+            .Replace("1", culture.NumberFormat.NativeDigits[1])
+            .Replace("2", culture.NumberFormat.NativeDigits[2])
+            .Replace("3", culture.NumberFormat.NativeDigits[3])
+            .Replace("4", culture.NumberFormat.NativeDigits[4])
+            .Replace("5", culture.NumberFormat.NativeDigits[5])
+            .Replace("6", culture.NumberFormat.NativeDigits[6])
+            .Replace("7", culture.NumberFormat.NativeDigits[7])
+            .Replace("8", culture.NumberFormat.NativeDigits[8])
+            .Replace("9", culture.NumberFormat.NativeDigits[9]);
+        var result = amount.ToAmountString(culture, true);
+        Assert.Equal(expected, result);
+    }
+    
+    [Theory]
+    [MemberData(nameof(GetSampleData))]
+    public void ToAmountString_AllCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
+    {
+        var expected = amount.ToString("C", culture);
+        if (culture.NumberFormat.CurrencyDecimalDigits == 99 && expected.Contains(culture.NumberFormat.CurrencyDecimalSeparator))
+        {
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+                expected = expected.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
+        }
+        if(culture.NumberFormat.CurrencyDecimalSeparator != culture.NumberFormat.CurrencySymbol)
+        { 
+            expected = expected.Remove(expected.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
+        }
+        var result = amount.ToAmountString(culture, false, false);
+        Assert.Equal(expected, result);
+    }
+    
+    [Theory]
+    [MemberData(nameof(GetSampleData))]
+    public void ToAmountString_AllCulturesShouldWorkWithOverwriteDecimal(CultureInfo culture, decimal amount)
+    {
+        //Arrange
+        var expected = amount.ToString("C6", culture).Replace("\u200b", "").Trim();
+        if (culture.Name is "kea-CV" or "pt-CV")
+        {
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencySymbol))
+                expected += "00"; // Make the currency symbol be in the center of the string
+        }
+        else
+        {
+            var symbolAtEnd = expected.EndsWith(culture.NumberFormat.CurrencySymbol);
+            if(symbolAtEnd)
+                expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+            {
+                expected = expected.Remove(expected.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
+            }
+            if (symbolAtEnd)
+                expected += (culture.NumberFormat.CurrencyPositivePattern == 3 ? " " : "") + culture.NumberFormat.CurrencySymbol;
+        }
+        //Act
+        var result = amount.ToAmountString(culture, false, overwriteDecimal: true);
+        //Assert
+        Assert.Equal(expected, result);
+    }
+}

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -11,13 +11,6 @@ public class CurrencyHelperTests
     public static IEnumerable<object[]> GetSampleData()
     {
         var cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures).AsEnumerable();
-        //Add a custom culture
-        var goldCulture = CultureInfo.InvariantCulture.Clone() as CultureInfo;
-        goldCulture!.NumberFormat.CurrencyDecimalDigits = 99;
-        goldCulture.NumberFormat.CurrencyDecimalSeparator = "*";
-        goldCulture.NumberFormat.CurrencyGroupSeparator = "/";
-        goldCulture.NumberFormat.CurrencySymbol = "\ud83e\ude99";
-        cultures = cultures.Append(goldCulture);
         foreach (var culture in cultures)
         {
             foreach (var number in SampleAmounts)
@@ -32,12 +25,6 @@ public class CurrencyHelperTests
     public void ToAmountString_AllCulturesShouldWorkByDefault(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
-        if (culture.NumberFormat.CurrencyDecimalDigits == 99 && expected.Contains(culture.NumberFormat.CurrencyDecimalSeparator))
-        {
-            expected = expected.TrimEnd('0');
-            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
-                expected = expected.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
-        }
         var result = amount.ToAmountString(culture, false);
         Assert.Equal(expected, result);
     }
@@ -47,12 +34,6 @@ public class CurrencyHelperTests
     public void ToAmountString_AllCulturesShouldWorkWithNativeDigits(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
-        if (culture.NumberFormat.CurrencyDecimalDigits == 99 && expected.Contains(culture.NumberFormat.CurrencyDecimalSeparator))
-        {
-            expected = expected.TrimEnd('0');
-            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
-                expected = expected.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
-        }
         expected =  expected
             .Replace("0", culture.NumberFormat.NativeDigits[0])
             .Replace("1", culture.NumberFormat.NativeDigits[1])
@@ -73,12 +54,6 @@ public class CurrencyHelperTests
     public void ToAmountString_AllCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
-        if (culture.NumberFormat.CurrencyDecimalDigits == 99 && expected.Contains(culture.NumberFormat.CurrencyDecimalSeparator))
-        {
-            expected = expected.TrimEnd('0');
-            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
-                expected = expected.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
-        }
         if(culture.NumberFormat.CurrencyDecimalSeparator != culture.NumberFormat.CurrencySymbol)
         { 
             expected = expected.Remove(expected.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -6,9 +6,9 @@ namespace NickvisionMoney.Shared.Tests;
 
 public class CurrencyHelperTests
 {
-    public static decimal[] SampleAmounts = { 0M, 109M, 100M, 10920M, 0.002M, 1.2M, 12.00000004M, 1.0234567890M };
-
-    public static IEnumerable<object[]> GetSampleData()
+    private static decimal[] SampleAmounts = { 0M, 109M, 100M, 10920M, 0.002M, 1.2M, 12.00000004M, 1.0234567890M };
+    
+    public static IEnumerable<object[]> GetSampleDataWithRealCultures()
     {
         var cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures).AsEnumerable();
         foreach (var culture in cultures)
@@ -20,9 +20,49 @@ public class CurrencyHelperTests
         }
     }
     
+    public static IEnumerable<object[]> GetSampleDataWithCustomCultures()
+    {
+        var culture1 = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        var culture2 = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        var culture3 = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        var culture4 = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        // Decimal digits
+        culture1.NumberFormat.CurrencyDecimalDigits = 1;
+        culture2.NumberFormat.CurrencyDecimalDigits = 2;
+        culture3.NumberFormat.CurrencyDecimalDigits = 3;
+        culture4.NumberFormat.CurrencyDecimalDigits = 99;
+        // Decimal separator
+        culture1.NumberFormat.CurrencyDecimalSeparator = ".";
+        culture2.NumberFormat.CurrencyDecimalSeparator = "/";
+        culture3.NumberFormat.CurrencyDecimalSeparator = "'";
+        culture4.NumberFormat.CurrencyDecimalSeparator = "*";
+        // Group separator
+        culture1.NumberFormat.CurrencyGroupSeparator = ",";
+        culture2.NumberFormat.CurrencyGroupSeparator = "-";
+        culture3.NumberFormat.CurrencyGroupSeparator = ".";
+        culture4.NumberFormat.CurrencyGroupSeparator = " ";
+        // Currency symbol
+        culture1.NumberFormat.CurrencySymbol = "\ud83e\ude99";
+        culture2.NumberFormat.CurrencySymbol = ":O";
+        culture3.NumberFormat.CurrencySymbol = ":D";
+        culture4.NumberFormat.CurrencySymbol = ":(";
+        // Currency positive pattern
+        culture1.NumberFormat.CurrencyPositivePattern = 0;
+        culture2.NumberFormat.CurrencyPositivePattern = 1;
+        culture3.NumberFormat.CurrencyPositivePattern = 2;
+        culture4.NumberFormat.CurrencyPositivePattern = 3;
+        foreach (var amount in SampleAmounts)
+        {
+            yield return new object[] { culture1, amount };
+            yield return new object[] { culture2, amount };
+            yield return new object[] { culture3, amount };
+            yield return new object[] { culture4, amount };
+        }
+    }
+    
     [Theory]
-    [MemberData(nameof(GetSampleData))]
-    public void ToAmountString_AllCulturesShouldWorkByDefault(CultureInfo culture, decimal amount)
+    [MemberData(nameof(GetSampleDataWithRealCultures))]
+    public void ToAmountString_RealCulturesShouldWorkByDefault(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
         var result = amount.ToAmountString(culture, false);
@@ -30,8 +70,20 @@ public class CurrencyHelperTests
     }
     
     [Theory]
-    [MemberData(nameof(GetSampleData))]
-    public void ToAmountString_AllCulturesShouldWorkWithNativeDigits(CultureInfo culture, decimal amount)
+    [MemberData(nameof(GetSampleDataWithCustomCultures))]
+    public void ToAmountString_CustomCulturesShouldWorkByDefault(CultureInfo culture, decimal amount)
+    {
+        var expected = amount.ToString("C", culture);
+        RemoveSymbol(ref expected, culture);
+        FormatUnlimitedDecimals(ref expected, culture);
+        AddSymbol(ref expected, culture);
+        var result = amount.ToAmountString(culture, false);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetSampleDataWithRealCultures))]
+    public void ToAmountString_RealCulturesShouldWorkWithNativeDigits(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
         expected =  expected
@@ -50,8 +102,8 @@ public class CurrencyHelperTests
     }
     
     [Theory]
-    [MemberData(nameof(GetSampleData))]
-    public void ToAmountString_AllCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
+    [MemberData(nameof(GetSampleDataWithRealCultures))]
+    public void ToAmountString_RealCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
         if(culture.NumberFormat.CurrencyDecimalSeparator != culture.NumberFormat.CurrencySymbol)
@@ -63,7 +115,18 @@ public class CurrencyHelperTests
     }
     
     [Theory]
-    [MemberData(nameof(GetSampleData))]
+    [MemberData(nameof(GetSampleDataWithCustomCultures))]
+    public void ToAmountString_CustomCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
+    {
+        var expected = amount.ToString("C", culture);
+        RemoveSymbol(ref expected, culture);
+        FormatUnlimitedDecimals(ref expected, culture);
+        var result = amount.ToAmountString(culture, false, false);
+        Assert.Equal(expected, result);
+    }
+    
+    [Theory]
+    [MemberData(nameof(GetSampleDataWithRealCultures))]
     public void ToAmountString_AllCulturesShouldWorkWithOverwriteDecimal(CultureInfo culture, decimal amount)
     {
         //Arrange
@@ -91,5 +154,41 @@ public class CurrencyHelperTests
         var result = amount.ToAmountString(culture, false, overwriteDecimal: true);
         //Assert
         Assert.Equal(expected, result);
+    }
+
+    private static void RemoveSymbol(ref string amount, CultureInfo culture)
+    {
+        amount = amount.Remove(amount.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
+        if (culture.NumberFormat.CurrencyDecimalDigits == 99)
+        {
+            amount = amount.TrimEnd('0');
+            if (amount.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+            {
+                amount = amount.Remove(amount.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
+            }
+        }
+    }
+    
+    private static void FormatUnlimitedDecimals(ref string number, CultureInfo culture)
+    {
+        if (culture.NumberFormat.NumberDecimalDigits == 99)
+        {
+            number = number
+                .Replace(culture.NumberFormat.CurrencySymbol, "")
+                .TrimEnd('0');
+        }
+    }
+
+    private static void AddSymbol(ref string amount, CultureInfo culture)
+    {
+        var formatString = culture.NumberFormat.CurrencyPositivePattern switch
+        {
+            0 => $"{culture.NumberFormat.CurrencySymbol}{{0}}",
+            1 => $"{{0}}{culture.NumberFormat.CurrencySymbol}",
+            2 => $"{culture.NumberFormat.CurrencySymbol} {{0}}",
+            3 => $"{{0}} {culture.NumberFormat.CurrencySymbol}",
+            _ => $"{culture.NumberFormat.CurrencySymbol}{{0}}"
+        };
+        amount = string.Format(formatString, amount);
     }
 }

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -108,7 +108,7 @@ public class CurrencyHelperTests
         var expected = amount.ToString("C", culture);
         if(culture.NumberFormat.CurrencyDecimalSeparator != culture.NumberFormat.CurrencySymbol)
         { 
-            expected = expected.Remove(expected.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
+            expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
         }
         var result = amount.ToAmountString(culture, false, false);
         Assert.Equal(expected, result);
@@ -134,7 +134,7 @@ public class CurrencyHelperTests
         if (culture.Name is "kea-CV" or "pt-CV")
         {
             expected = expected.TrimEnd('0');
-            if (expected.EndsWith(culture.NumberFormat.CurrencySymbol))
+            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
                 expected += "00"; // Make the currency symbol be in the center of the string
         }
         else

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -106,10 +106,7 @@ public class CurrencyHelperTests
     public void ToAmountString_RealCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
-        if(culture.NumberFormat.CurrencyDecimalSeparator != culture.NumberFormat.CurrencySymbol)
-        { 
-            expected = expected.Remove(expected.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
-        }
+        expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
         var result = amount.ToAmountString(culture, false, false);
         Assert.Equal(expected, result);
     }
@@ -131,25 +128,16 @@ public class CurrencyHelperTests
     {
         //Arrange
         var expected = amount.ToString("C6", culture).Replace("\u200b", "").Trim();
-        if (culture.Name is "kea-CV" or "pt-CV")
+        var symbolAtEnd = expected.EndsWith(culture.NumberFormat.CurrencySymbol);
+        if(symbolAtEnd)
+            expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
+        expected = expected.TrimEnd('0');
+        if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
         {
-            expected = expected.TrimEnd('0');
-            if (expected.EndsWith(culture.NumberFormat.CurrencySymbol))
-                expected += "00"; // Make the currency symbol be in the center of the string
+            expected = expected.Remove(expected.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
         }
-        else
-        {
-            var symbolAtEnd = expected.EndsWith(culture.NumberFormat.CurrencySymbol);
-            if(symbolAtEnd)
-                expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
-            expected = expected.TrimEnd('0');
-            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
-            {
-                expected = expected.Remove(expected.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
-            }
-            if (symbolAtEnd)
-                expected += (culture.NumberFormat.CurrencyPositivePattern == 3 ? " " : "") + culture.NumberFormat.CurrencySymbol;
-        }
+        if (symbolAtEnd)
+            expected += (culture.NumberFormat.CurrencyPositivePattern == 3 ? " " : "") + culture.NumberFormat.CurrencySymbol;
         //Act
         var result = amount.ToAmountString(culture, false, overwriteDecimal: true);
         //Assert

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -134,8 +134,12 @@ public class CurrencyHelperTests
         if (culture.Name is "kea-CV" or "pt-CV")
         {
             expected = expected.TrimEnd('0');
+            // Make the currency decomal separator be in the center of the string
             if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
-                expected += "00"; // Make the currency symbol be in the center of the string
+                expected += "00";
+            else if (expected.Substring(expected.IndexOf(culture.NumberFormat.CurrencyDecimalSeparator) + 1).Length == 1)
+                expected += "0";
+            expected = $"{expected} \u200b";
         }
         else
         {

--- a/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
+++ b/NickvisionMoney.Shared.Tests/CurrencyHelperTests.cs
@@ -106,7 +106,10 @@ public class CurrencyHelperTests
     public void ToAmountString_RealCulturesShouldWorkWithoutCurrencySymbol(CultureInfo culture, decimal amount)
     {
         var expected = amount.ToString("C", culture);
-        expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
+        if(culture.NumberFormat.CurrencyDecimalSeparator != culture.NumberFormat.CurrencySymbol)
+        { 
+            expected = expected.Remove(expected.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
+        }
         var result = amount.ToAmountString(culture, false, false);
         Assert.Equal(expected, result);
     }
@@ -128,16 +131,25 @@ public class CurrencyHelperTests
     {
         //Arrange
         var expected = amount.ToString("C6", culture).Replace("\u200b", "").Trim();
-        var symbolAtEnd = expected.EndsWith(culture.NumberFormat.CurrencySymbol);
-        if(symbolAtEnd)
-            expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
-        expected = expected.TrimEnd('0');
-        if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+        if (culture.Name is "kea-CV" or "pt-CV")
         {
-            expected = expected.Remove(expected.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencySymbol))
+                expected += "00"; // Make the currency symbol be in the center of the string
         }
-        if (symbolAtEnd)
-            expected += (culture.NumberFormat.CurrencyPositivePattern == 3 ? " " : "") + culture.NumberFormat.CurrencySymbol;
+        else
+        {
+            var symbolAtEnd = expected.EndsWith(culture.NumberFormat.CurrencySymbol);
+            if(symbolAtEnd)
+                expected = expected.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
+            expected = expected.TrimEnd('0');
+            if (expected.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
+            {
+                expected = expected.Remove(expected.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
+            }
+            if (symbolAtEnd)
+                expected += (culture.NumberFormat.CurrencyPositivePattern == 3 ? " " : "") + culture.NumberFormat.CurrencySymbol;
+        }
         //Act
         var result = amount.ToAmountString(culture, false, overwriteDecimal: true);
         //Assert

--- a/NickvisionMoney.Shared.Tests/NickvisionMoney.Shared.Tests.csproj
+++ b/NickvisionMoney.Shared.Tests/NickvisionMoney.Shared.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NickvisionMoney.Shared\NickvisionMoney.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
@@ -28,6 +28,10 @@ public static class CurrencyHelpers
             {
                 result = culture.Name is "kea-CV" or "pt-CV" ? $"{result}00" : result.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
             }
+            else if (result.Substring(result.IndexOf(culture.NumberFormat.CurrencyDecimalSeparator) + 1).Length == 1 && culture.Name is "kea-CV" or "pt-CV")
+            {
+                result = $"{result}0";
+            }
         }
         if (showCurrencySymbol)
         {

--- a/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
@@ -20,7 +20,7 @@ public static class CurrencyHelpers
     public static string ToAmountString(this decimal amount, CultureInfo culture, bool useNativeDigits, bool showCurrencySymbol = true, bool overwriteDecimal = false)
     {
         var result = Math.Abs(amount).ToString(overwriteDecimal ? "C6" : "C", culture);
-        result = result.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
+        result = result.Remove(result.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
         if (culture.NumberFormat.CurrencyDecimalDigits == 99 || overwriteDecimal)
         {
             result = result.TrimEnd('0');

--- a/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
@@ -19,14 +19,14 @@ public static class CurrencyHelpers
     /// <returns>Formatted amount string</returns>
     public static string ToAmountString(this decimal amount, CultureInfo culture, bool useNativeDigits, bool showCurrencySymbol = true, bool overwriteDecimal = false)
     {
-        var result = Math.Abs(amount).ToString(overwriteDecimal ? "C6" : "C", culture);
-        result = result.Remove(result.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
+        var result = Math.Abs(amount).ToString(overwriteDecimal ? "C6" : culture.Name is "kea-CV" or "pt-CV" ? "C2" : "C", culture);
+        result = result.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
         if (culture.NumberFormat.CurrencyDecimalDigits == 99 || overwriteDecimal)
         {
             result = result.TrimEnd('0');
             if (result.EndsWith(culture.NumberFormat.CurrencyDecimalSeparator))
             {
-                result = result.Remove(result.LastIndexOf(culture.NumberFormat.CurrencyDecimalSeparator));
+                result = culture.Name is "kea-CV" or "pt-CV" ? $"{result}00" : result.Replace(culture.NumberFormat.CurrencyDecimalSeparator, "");
             }
         }
         if (showCurrencySymbol)

--- a/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CurrencyHelpers.cs
@@ -20,7 +20,7 @@ public static class CurrencyHelpers
     public static string ToAmountString(this decimal amount, CultureInfo culture, bool useNativeDigits, bool showCurrencySymbol = true, bool overwriteDecimal = false)
     {
         var result = Math.Abs(amount).ToString(overwriteDecimal ? "C6" : "C", culture);
-        result = result.Remove(result.IndexOf(culture.NumberFormat.CurrencySymbol), culture.NumberFormat.CurrencySymbol.Length).Trim();
+        result = result.Replace(culture.NumberFormat.CurrencySymbol, "").Trim();
         if (culture.NumberFormat.CurrencyDecimalDigits == 99 || overwriteDecimal)
         {
             result = result.TrimEnd('0');

--- a/NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in
+++ b/NickvisionMoney.Shared/org.nickvision.money.metainfo.xml.in
@@ -52,6 +52,7 @@
         <p>- Fixed an issue where the currency conversion service would provide the wrong conversion rate</p>
         <p>- Fixed an issue where small converted currency amounts would show as 0</p>
         <p>- Improved UX in Currency Converter dialog</p>
+        <p>- Fixed incorrect display of amounts for locales that use Cape Verdean escudo as currency</p>
         <p>- Updated translations (Thanks to everyone on Weblate)!</p>
       </description>
     </release>


### PR DESCRIPTION
 Tests added for CurrencyHelpers to make sure it works with all cultures.
 
 I hardcoded some values because in the tests we know exactly what values go into the test methods and what the expected output is.
 
 Currently all tests are passing except "kea-CV" and "pt-CV". These cultures have $ in the middle of the number: 
 $1.00 -> 1$00 
 $2.05 -> 2$05
 Also for some reason they also have a zero width space at the end of the number. 
 