### PR TITLE
Use IsNullOrWhitespace instead of IsNullOrEmpty

### DIFF
--- a/NickvisionMoney.GNOME/Controls/CurrencyConverterDialog.cs
+++ b/NickvisionMoney.GNOME/Controls/CurrencyConverterDialog.cs
@@ -70,7 +70,7 @@ public class CurrencyConverterDialog : Adw.Window
         };
         _copyResultButton.OnClicked += (sender, e) =>
         {
-            if (!string.IsNullOrEmpty(_resultAmountRow.GetText()))
+            if (!string.IsNullOrWhiteSpace(_resultAmountRow.GetText()))
             {
                 _resultAmountRow.GetClipboard().SetText(_resultAmountRow.GetText());
                 _toastOverlay.AddToast(Adw.Toast.New(_("Result was copied to clipboard.")));
@@ -136,7 +136,7 @@ public class CurrencyConverterDialog : Adw.Window
     private async Task OnAmountRowChangedAsync()
     {
         _sourceAmountRow.RemoveCssClass("error");
-        if (string.IsNullOrEmpty(_sourceAmountRow.GetText()))
+        if (string.IsNullOrWhiteSpace(_sourceAmountRow.GetText()))
         {
             _resultAmountRow.SetText("");
         }

--- a/NickvisionMoney.GNOME/Controls/NewPasswordDialog.cs
+++ b/NickvisionMoney.GNOME/Controls/NewPasswordDialog.cs
@@ -62,7 +62,7 @@ public partial class NewPasswordDialog : Adw.Window
     /// </summary>
     private void Validate()
     {
-        if (_newPasswordEntry.GetText() != _confirmPasswordEntry.GetText() || string.IsNullOrWhiteSpace(_newPasswordEntry.GetText()))
+        if (_newPasswordEntry.GetText() != _confirmPasswordEntry.GetText() || string.IsNullOrEmpty(_newPasswordEntry.GetText()))
         {
             _addButton.SetSensitive(false);
         }

--- a/NickvisionMoney.GNOME/Controls/NewPasswordDialog.cs
+++ b/NickvisionMoney.GNOME/Controls/NewPasswordDialog.cs
@@ -62,7 +62,7 @@ public partial class NewPasswordDialog : Adw.Window
     /// </summary>
     private void Validate()
     {
-        if (_newPasswordEntry.GetText() != _confirmPasswordEntry.GetText() || string.IsNullOrEmpty(_newPasswordEntry.GetText()))
+        if (_newPasswordEntry.GetText() != _confirmPasswordEntry.GetText() || string.IsNullOrWhiteSpace(_newPasswordEntry.GetText()))
         {
             _addButton.SetSensitive(false);
         }

--- a/NickvisionMoney.GNOME/Program.cs
+++ b/NickvisionMoney.GNOME/Program.cs
@@ -45,6 +45,8 @@ public partial class Program
             @"* Fixed an issue where exported PDF values were incorrect
               * Fixed an issue where some system cultures were not read properly
               * Fixed an issue where scrolling the sidebar with the mouse over the calendar would scroll the calendar instead
+              * Disallowed whitespace-only group and account names
+              * Fixed an issue where leading or trailing spaces in group/account names aren't discarded
               * Updated to GNOME 45 runtime with latest libadwaita design
               * Updated and added translations (Thanks to everyone on Weblate)!";
         _application.OnActivate += OnActivate;

--- a/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
+++ b/NickvisionMoney.GNOME/Views/AccountSettingsDialog.cs
@@ -359,7 +359,7 @@ public partial class AccountSettingsDialog : Adw.Window
         };
         var customDecimalDigits = _customDecimalDigitsRow.GetSelected() == 5 ? 99 : _customDecimalDigitsRow.GetSelected() + 2;
         var oldSymbol = _controller.Metadata.CustomCurrencySymbol;
-        var checkStatus = _controller.UpdateMetadata(_nameRow.GetText(), (AccountType)_accountTypeRow.GetSelected(), _useCustomCurrencyRow.GetActive(), _customSymbolRow.GetText(), _customCodeRow.GetText(), (int?)_customAmountStyleRow.GetSelected(), customDecimalSeparator, customGroupSeparator, (int?)customDecimalDigits, transactionType, (RemindersThreshold)_transactionRemindersRow.GetSelected(), _newPasswordRow.GetText(), _newPasswordConfirmRow.GetText());
+        var checkStatus = _controller.UpdateMetadata(_nameRow.GetText().Trim(), (AccountType)_accountTypeRow.GetSelected(), _useCustomCurrencyRow.GetActive(), _customSymbolRow.GetText(), _customCodeRow.GetText(), (int?)_customAmountStyleRow.GetSelected(), customDecimalSeparator, customGroupSeparator, (int?)customDecimalDigits, transactionType, (RemindersThreshold)_transactionRemindersRow.GetSelected(), _newPasswordRow.GetText(), _newPasswordConfirmRow.GetText());
         _nameRow.RemoveCssClass("error");
         _nameRow.SetTitle(_("Name"));
         _customCurrencyRow.RemoveCssClass("error");

--- a/NickvisionMoney.GNOME/Views/GroupDialog.cs
+++ b/NickvisionMoney.GNOME/Views/GroupDialog.cs
@@ -140,7 +140,7 @@ public partial class GroupDialog : Adw.Window
     private void Validate()
     {
         var color = _colorButton.GetExtRgba();
-        var checkStatus = _controller.UpdateGroup(_nameRow.GetText(), _descriptionRow.GetText(), color.ToString());
+        var checkStatus = _controller.UpdateGroup(_nameRow.GetText().Trim(), _descriptionRow.GetText().Trim(), color.ToString());
         _nameRow.RemoveCssClass("error");
         _nameRow.SetTitle(_("Name"));
         if (checkStatus == GroupCheckStatus.Valid)

--- a/NickvisionMoney.GNOME/Views/MainWindow.cs
+++ b/NickvisionMoney.GNOME/Views/MainWindow.cs
@@ -206,7 +206,7 @@ public partial class MainWindow : Adw.ApplicationWindow
             NotificationSeverity.Error => Gio.NotificationPriority.Urgent,
             _ => Gio.NotificationPriority.Normal
         });
-        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SNAP")))
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SNAP")))
         {
             notification.SetIcon(Gio.ThemedIcon.New($"{_controller.AppInfo.ID}-symbolic"));
         }
@@ -429,7 +429,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         {
             debugInfo.AppendLine("Flatpak");
         }
-        else if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SNAP")))
+        else if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SNAP")))
         {
             debugInfo.AppendLine("Snap");
         }

--- a/NickvisionMoney.GNOME/Views/NewAccountDialog.cs
+++ b/NickvisionMoney.GNOME/Views/NewAccountDialog.cs
@@ -311,7 +311,7 @@ public partial class NewAccountDialog : Adw.Window
     /// </summary>
     private void ShowPasswordStrength()
     {
-        if (!string.IsNullOrWhiteSpace(_accountPasswordRow.GetText()))
+        if (!string.IsNullOrEmpty(_accountPasswordRow.GetText()))
         {
             var strength = Credential.GetPasswordStrength(_accountPasswordRow.GetText());
             _accountPasswordStrengthRow.SetVisible(true);

--- a/NickvisionMoney.GNOME/Views/NewAccountDialog.cs
+++ b/NickvisionMoney.GNOME/Views/NewAccountDialog.cs
@@ -285,7 +285,7 @@ public partial class NewAccountDialog : Adw.Window
     {
         _accountNameRow.RemoveCssClass("error");
         _accountNameRow.SetTitle(_("Account Name"));
-        var checkStatus = _controller.UpdateName(_accountNameRow.GetText());
+        var checkStatus = _controller.UpdateName(_accountNameRow.GetText().Trim());
         if (checkStatus == NameCheckStatus.Valid)
         {
             _nextButton1.SetSensitive(!string.IsNullOrWhiteSpace(_accountNameRow.GetText()));

--- a/NickvisionMoney.GNOME/Views/NewAccountDialog.cs
+++ b/NickvisionMoney.GNOME/Views/NewAccountDialog.cs
@@ -288,7 +288,7 @@ public partial class NewAccountDialog : Adw.Window
         var checkStatus = _controller.UpdateName(_accountNameRow.GetText());
         if (checkStatus == NameCheckStatus.Valid)
         {
-            _nextButton1.SetSensitive(!string.IsNullOrEmpty(_accountNameRow.GetText()));
+            _nextButton1.SetSensitive(!string.IsNullOrWhiteSpace(_accountNameRow.GetText()));
         }
         else
         {
@@ -311,7 +311,7 @@ public partial class NewAccountDialog : Adw.Window
     /// </summary>
     private void ShowPasswordStrength()
     {
-        if (!string.IsNullOrEmpty(_accountPasswordRow.GetText()))
+        if (!string.IsNullOrWhiteSpace(_accountPasswordRow.GetText()))
         {
             var strength = Credential.GetPasswordStrength(_accountPasswordRow.GetText());
             _accountPasswordStrengthRow.SetVisible(true);

--- a/NickvisionMoney.GNOME/Views/TransactionDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransactionDialog.cs
@@ -351,7 +351,7 @@ public partial class TransactionDialog : Adw.Window
         _addTagButton.OnClicked += (sender, e) =>
         {
             var tag = _addTagEntry.GetBuffer().GetText().Trim();
-            if (!string.IsNullOrEmpty(tag) && !_controller.AccountTags.Contains(tag))
+            if (!string.IsNullOrWhiteSpace(tag) && !_controller.AccountTags.Contains(tag))
             {
                 _controller.AccountTags.Add(tag);
                 UpdateTagsList();

--- a/NickvisionMoney.GNOME/Views/TransferDialog.cs
+++ b/NickvisionMoney.GNOME/Views/TransferDialog.cs
@@ -305,7 +305,7 @@ public partial class TransferDialog : Adw.Window
         if (_conversionRateGroup.Visible)
         {
             var res = await _controller.GetConversionRateOnlineAsync();
-            if (string.IsNullOrEmpty(res.Source) || string.IsNullOrEmpty(res.Destination))
+            if (string.IsNullOrWhiteSpace(res.Source) || string.IsNullOrWhiteSpace(res.Destination))
             {
                 _sourceCurrencyRow.SetText("");
                 _destinationCurrencyRow.SetText("");

--- a/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
@@ -81,7 +81,7 @@ public class AccountSettingsDialogController
     public AccountMetadataCheckStatus UpdateMetadata(string name, AccountType type, bool useCustom, string? customSymbol, string? customCode, int? customAmountStyle, string? customDecimalSeparator, string? customGroupSeparator, int? customDecimalDigits, TransactionType defaultTransactionType, RemindersThreshold transactionReminder, string newPassword, string confirmPassword)
     {
         AccountMetadataCheckStatus result = 0;
-        if (string.IsNullOrEmpty(name))
+        if (string.IsNullOrWhiteSpace(name))
         {
             result |= AccountMetadataCheckStatus.EmptyName;
         }
@@ -152,7 +152,7 @@ public class AccountSettingsDialogController
         }
         Metadata.DefaultTransactionType = defaultTransactionType;
         Metadata.TransactionRemindersThreshold = transactionReminder;
-        NewPassword = string.IsNullOrEmpty(newPassword) ? (NewPassword == "" ? "" : null) : newPassword;
+        NewPassword = string.IsNullOrWhiteSpace(newPassword) ? (NewPassword == "" ? "" : null) : newPassword;
         return AccountMetadataCheckStatus.Valid;
     }
 

--- a/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
@@ -85,15 +85,15 @@ public class AccountSettingsDialogController
         {
             result |= AccountMetadataCheckStatus.EmptyName;
         }
-        if (useCustom && string.IsNullOrEmpty(customSymbol))
+        if (useCustom && string.IsNullOrWhiteSpace(customSymbol))
         {
             result |= AccountMetadataCheckStatus.EmptyCurrencySymbol;
         }
-        if (useCustom && !string.IsNullOrEmpty(customSymbol) && Decimal.TryParse(customSymbol, out _))
+        if (useCustom && !string.IsNullOrWhiteSpace(customSymbol) && Decimal.TryParse(customSymbol, out _))
         {
             result |= AccountMetadataCheckStatus.InvalidCurrencySymbol;
         }
-        if (useCustom && string.IsNullOrEmpty(customCode))
+        if (useCustom && string.IsNullOrWhiteSpace(customCode))
         {
             result |= AccountMetadataCheckStatus.EmptyCurrencyCode;
         }

--- a/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountSettingsDialogController.cs
@@ -152,7 +152,7 @@ public class AccountSettingsDialogController
         }
         Metadata.DefaultTransactionType = defaultTransactionType;
         Metadata.TransactionRemindersThreshold = transactionReminder;
-        NewPassword = string.IsNullOrWhiteSpace(newPassword) ? (NewPassword == "" ? "" : null) : newPassword;
+        NewPassword = string.IsNullOrEmpty(newPassword) ? (NewPassword == "" ? "" : null) : newPassword;
         return AccountMetadataCheckStatus.Valid;
     }
 

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -571,7 +571,7 @@ public class AccountViewController : IDisposable
         _account.Password = password;
         if (showNotification)
         {
-            if (string.IsNullOrEmpty(password))
+            if (string.IsNullOrWhiteSpace(password))
             {
                 NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("The password of the account was removed."), NotificationSeverity.Success));
             }
@@ -1127,7 +1127,7 @@ public class AccountViewController : IDisposable
         var groupBalances = new Dictionary<uint, (decimal Income, decimal Expense)>();
         foreach (var pair in _account.Transactions)
         {
-            if (!string.IsNullOrEmpty(SearchDescription))
+            if (!string.IsNullOrWhiteSpace(SearchDescription))
             {
                 if (!pair.Value.Description.ToLower().Contains(SearchDescription.ToLower()))
                 {

--- a/NickvisionMoney.Shared/Controllers/AccountViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/AccountViewController.cs
@@ -571,7 +571,7 @@ public class AccountViewController : IDisposable
         _account.Password = password;
         if (showNotification)
         {
-            if (string.IsNullOrWhiteSpace(password))
+            if (string.IsNullOrEmpty(password))
             {
                 NotificationSent?.Invoke(this, new NotificationSentEventArgs(_("The password of the account was removed."), NotificationSeverity.Success));
             }

--- a/NickvisionMoney.Shared/Controllers/DashboardViewController.cs
+++ b/NickvisionMoney.Shared/Controllers/DashboardViewController.cs
@@ -110,7 +110,7 @@ public class DashboardViewController
                     name = nameBuilder.ToString();
                     if (!Groups.ContainsKey(name))
                     {
-                        Groups[name] = (new DashboardAmount(), string.IsNullOrEmpty(group.RGBA) ? defaultColor : group.RGBA);
+                        Groups[name] = (new DashboardAmount(), string.IsNullOrWhiteSpace(group.RGBA) ? defaultColor : group.RGBA);
                     }
                     if (!Groups[name].DashboardAmount.Currencies.Contains(currency))
                     {

--- a/NickvisionMoney.Shared/Controllers/GroupDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/GroupDialogController.cs
@@ -58,7 +58,7 @@ public class GroupDialogController
         _existingNames = existingNames;
         Group = (Group)group.Clone();
         IsEditing = true;
-        if (string.IsNullOrEmpty(Group.RGBA))
+        if (string.IsNullOrWhiteSpace(Group.RGBA))
         {
             Group.RGBA = groupDefaultColor;
         }
@@ -90,7 +90,7 @@ public class GroupDialogController
     /// <returns>GroupCheckStatus</returns>
     public GroupCheckStatus UpdateGroup(string name, string description, string rgba)
     {
-        if (string.IsNullOrEmpty(name))
+        if (string.IsNullOrWhiteSpace(name))
         {
             return GroupCheckStatus.EmptyName;
         }

--- a/NickvisionMoney.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionMoney.Shared/Controllers/MainWindowController.cs
@@ -296,7 +296,7 @@ public class MainWindowController : IDisposable
         AccountAdded?.Invoke(this, EventArgs.Empty);
         await Task.Delay(100);
         accountViewController.UpdateMetadata(controller.Metadata);
-        if (!string.IsNullOrEmpty(controller.Password))
+        if (!string.IsNullOrWhiteSpace(controller.Password))
         {
             accountViewController.SetPassword(controller.Password, false);
         }
@@ -326,7 +326,7 @@ public class MainWindowController : IDisposable
             controller.TransferSent += OnTransferSent;
             try
             {
-                if (controller.AccountNeedsPassword && string.IsNullOrEmpty(password))
+                if (controller.AccountNeedsPassword && string.IsNullOrWhiteSpace(password))
                 {
                     password = await AccountLoginAsync!(controller.AccountPath);
                 }

--- a/NickvisionMoney.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionMoney.Shared/Controllers/MainWindowController.cs
@@ -296,7 +296,7 @@ public class MainWindowController : IDisposable
         AccountAdded?.Invoke(this, EventArgs.Empty);
         await Task.Delay(100);
         accountViewController.UpdateMetadata(controller.Metadata);
-        if (!string.IsNullOrWhiteSpace(controller.Password))
+        if (!string.IsNullOrEmpty(controller.Password))
         {
             accountViewController.SetPassword(controller.Password, false);
         }
@@ -326,7 +326,7 @@ public class MainWindowController : IDisposable
             controller.TransferSent += OnTransferSent;
             try
             {
-                if (controller.AccountNeedsPassword && string.IsNullOrWhiteSpace(password))
+                if (controller.AccountNeedsPassword && string.IsNullOrEmpty(password))
                 {
                     password = await AccountLoginAsync!(controller.AccountPath);
                 }

--- a/NickvisionMoney.Shared/Controllers/NewAccountDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/NewAccountDialogController.cs
@@ -123,15 +123,15 @@ public class NewAccountDialogController
     public CurrencyCheckStatus UpdateCurrency(bool useCustom, string? customSymbol, string? customCode, int? customAmountStyle, string? customDecimalSeparator, string? customGroupSeparator, int? customDecimalDigits)
     {
         CurrencyCheckStatus result = 0;
-        if (useCustom && string.IsNullOrEmpty(customSymbol))
+        if (useCustom && string.IsNullOrWhiteSpace(customSymbol))
         {
             result |= CurrencyCheckStatus.EmptyCurrencySymbol;
         }
-        if (useCustom && !string.IsNullOrEmpty(customSymbol) && Decimal.TryParse(customSymbol, out _))
+        if (useCustom && !string.IsNullOrWhiteSpace(customSymbol) && Decimal.TryParse(customSymbol, out _))
         {
             result |= CurrencyCheckStatus.InvalidCurrencySymbol;
         }
-        if (useCustom && string.IsNullOrEmpty(customCode))
+        if (useCustom && string.IsNullOrWhiteSpace(customCode))
         {
             result |= CurrencyCheckStatus.EmptyCurrencyCode;
         }

--- a/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransactionDialogController.cs
@@ -114,7 +114,7 @@ public class TransactionDialogController : IDisposable
         CopyRequested = false;
         OriginalRepeatInterval = Transaction.RepeatInterval;
         CultureForNumberString = cultureNumber;
-        if (string.IsNullOrEmpty(Transaction.RGBA))
+        if (string.IsNullOrWhiteSpace(Transaction.RGBA))
         {
             Transaction.RGBA = DefaultTransactionColor;
         }
@@ -300,7 +300,7 @@ public class TransactionDialogController : IDisposable
     {
         TransactionCheckStatus result = 0;
         var amount = 0m;
-        if (string.IsNullOrEmpty(description))
+        if (string.IsNullOrWhiteSpace(description))
         {
             result |= TransactionCheckStatus.EmptyDescription;
         }

--- a/NickvisionMoney.Shared/Controllers/TransferDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransferDialogController.cs
@@ -142,13 +142,13 @@ public class TransferDialogController
         TransferCheckStatus result = 0;
         var amount = 0m;
         var conversionRate = 0m;
-        if (string.IsNullOrEmpty(destPath) || !Path.Exists(destPath) || Path.GetExtension(destPath).ToLower() != ".nmoney" || Transfer.SourceAccountPath == destPath)
+        if (string.IsNullOrWhiteSpace(destPath) || !Path.Exists(destPath) || Path.GetExtension(destPath).ToLower() != ".nmoney" || Transfer.SourceAccountPath == destPath)
         {
             result |= TransferCheckStatus.InvalidDestPath;
         }
         else
         {
-            if (new Account(destPath).IsEncrypted && string.IsNullOrEmpty(destPassword))
+            if (new Account(destPath).IsEncrypted && string.IsNullOrWhiteSpace(destPassword))
             {
                 result |= TransferCheckStatus.DestAccountRequiresPassword;
             }
@@ -172,8 +172,8 @@ public class TransferDialogController
                 {
                     lcMonetary = lcMonetary.Replace('@', '-');
                 }
-                CultureForDestNumberString = new CultureInfo(!string.IsNullOrEmpty(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name, true);
-                var destRegion = new RegionInfo(!string.IsNullOrEmpty(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
+                CultureForDestNumberString = new CultureInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name, true);
+                var destRegion = new RegionInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
                 if (_previousDestMetadata == null)
                 {
                     _previousDestMetadata = AccountMetadata.LoadFromAccountFile(destPath, destPassword)!;

--- a/NickvisionMoney.Shared/Controllers/TransferDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransferDialogController.cs
@@ -116,7 +116,7 @@ public class TransferDialogController
     /// <returns>(string Source, string Destination)</returns>
     public async Task<(string Source, string Destination)> GetConversionRateOnlineAsync()
     {
-        if (string.IsNullOrEmpty(DestinationCurrencyCode))
+        if (string.IsNullOrWhiteSpace(DestinationCurrencyCode))
         {
             return ("", "");
         }

--- a/NickvisionMoney.Shared/Controllers/TransferDialogController.cs
+++ b/NickvisionMoney.Shared/Controllers/TransferDialogController.cs
@@ -148,7 +148,7 @@ public class TransferDialogController
         }
         else
         {
-            if (new Account(destPath).IsEncrypted && string.IsNullOrWhiteSpace(destPassword))
+            if (new Account(destPath).IsEncrypted && string.IsNullOrEmpty(destPassword))
             {
                 result |= TransferCheckStatus.DestAccountRequiresPassword;
             }

--- a/NickvisionMoney.Shared/Helpers/CultureHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CultureHelpers.cs
@@ -89,8 +89,8 @@ public static class CultureHelpers
         var region = new RegionInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
         if (metadata.UseCustomCurrency)
         {
-            culture.NumberFormat.CurrencySymbol = string.IsNullOrEmpty(metadata.CustomCurrencySymbol) ? culture.NumberFormat.CurrencySymbol : metadata.CustomCurrencySymbol;
-            culture.NumberFormat.NaNSymbol = string.IsNullOrEmpty(metadata.CustomCurrencyCode) ? region.ISOCurrencySymbol : metadata.CustomCurrencyCode;
+            culture.NumberFormat.CurrencySymbol = string.IsNullOrWhiteSpace(metadata.CustomCurrencySymbol) ? culture.NumberFormat.CurrencySymbol : metadata.CustomCurrencySymbol;
+            culture.NumberFormat.NaNSymbol = string.IsNullOrWhiteSpace(metadata.CustomCurrencyCode) ? region.ISOCurrencySymbol : metadata.CustomCurrencyCode;
             culture.NumberFormat.CurrencyPositivePattern = metadata.CustomCurrencyAmountStyle ?? culture.NumberFormat.CurrencyPositivePattern;
             culture.NumberFormat.CurrencyDecimalSeparator = string.IsNullOrEmpty(metadata.CustomCurrencyDecimalSeparator) ? culture.NumberFormat.CurrencyDecimalSeparator : metadata.CustomCurrencyDecimalSeparator;
             culture.NumberFormat.NumberDecimalSeparator = string.IsNullOrEmpty(metadata.CustomCurrencyDecimalSeparator) ? culture.NumberFormat.NumberDecimalSeparator : metadata.CustomCurrencyDecimalSeparator;

--- a/NickvisionMoney.Shared/Helpers/CultureHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/CultureHelpers.cs
@@ -37,7 +37,7 @@ public static class CultureHelpers
         {
             lcTime = lcTime.Replace('_', '-');
         }
-        DateCulture = new CultureInfo(!string.IsNullOrEmpty(lcTime) ? lcTime : CultureInfo.CurrentCulture.Name, true);
+        DateCulture = new CultureInfo(!string.IsNullOrWhiteSpace(lcTime) ? lcTime : CultureInfo.CurrentCulture.Name, true);
         //Reported Currency String
         var lcMonetary = Environment.GetEnvironmentVariable("LC_MONETARY");
         if (lcMonetary != null && lcMonetary.Contains(".UTF-8"))
@@ -56,8 +56,8 @@ public static class CultureHelpers
         {
             lcMonetary = lcMonetary.Replace('@', '-');
         }
-        var culture = new CultureInfo(!string.IsNullOrEmpty(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name, true);
-        var region = new RegionInfo(!string.IsNullOrEmpty(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
+        var culture = new CultureInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name, true);
+        var region = new RegionInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
         ReportedCurrencyString = $"{culture.NumberFormat.CurrencySymbol} ({region.ISOCurrencySymbol})";
     }
 
@@ -85,8 +85,8 @@ public static class CultureHelpers
         {
             lcMonetary = lcMonetary.Replace('@', '-');
         }
-        var culture = new CultureInfo(!string.IsNullOrEmpty(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name, true);
-        var region = new RegionInfo(!string.IsNullOrEmpty(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
+        var culture = new CultureInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name, true);
+        var region = new RegionInfo(!string.IsNullOrWhiteSpace(lcMonetary) ? lcMonetary : CultureInfo.CurrentCulture.Name);
         if (metadata.UseCustomCurrency)
         {
             culture.NumberFormat.CurrencySymbol = string.IsNullOrEmpty(metadata.CustomCurrencySymbol) ? culture.NumberFormat.CurrencySymbol : metadata.CustomCurrencySymbol;

--- a/NickvisionMoney.Shared/Helpers/DocumentationHelpers.cs
+++ b/NickvisionMoney.Shared/Helpers/DocumentationHelpers.cs
@@ -19,7 +19,7 @@ public static class DocumentationHelpers
     /// <returns>URL to either yelp or web page</returns>
     public static string GetHelpURL(string pageName)
     {
-        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SNAP")) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SNAP")) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             return $"help:tagger/{pageName}";
         }

--- a/NickvisionMoney.Shared/Linux/org.nickvision.money.metainfo.xml.in
+++ b/NickvisionMoney.Shared/Linux/org.nickvision.money.metainfo.xml.in
@@ -52,6 +52,8 @@
         <p>- Fixed an issue where exported PDF values were incorrect</p>
         <p>- Fixed an issue where some system cultures were not read properly</p>
         <p>- Fixed an issue where scrolling the sidebar with the mouse over the calendar would scroll the calendar instead</p>
+        <p>- Disallowed whitespace-only group and account names</p>
+        <p>- Fixed an issue where leading or trailing spaces in group/account names aren't discarded</p>
         <p>- Updated to GNOME 45 runtime with latest libadwaita design</p>
         <p>- Updated translations (Thanks to everyone on Weblate)!</p>
       </description>

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -431,8 +431,8 @@ public class Account : IDisposable
             Metadata.Name = readQueryMetadata.GetString(1);
             Metadata.AccountType = (AccountType)readQueryMetadata.GetInt32(2);
             Metadata.UseCustomCurrency = readQueryMetadata.GetBoolean(3);
-            Metadata.CustomCurrencySymbol = string.IsNullOrEmpty(readQueryMetadata.GetString(4)) ? null : readQueryMetadata.GetString(4);
-            Metadata.CustomCurrencyCode = string.IsNullOrEmpty(readQueryMetadata.GetString(5)) ? null : readQueryMetadata.GetString(5);
+            Metadata.CustomCurrencySymbol = string.IsNullOrWhiteSpace(readQueryMetadata.GetString(4)) ? null : readQueryMetadata.GetString(4);
+            Metadata.CustomCurrencyCode = string.IsNullOrWhiteSpace(readQueryMetadata.GetString(5)) ? null : readQueryMetadata.GetString(5);
             Metadata.DefaultTransactionType = (TransactionType)readQueryMetadata.GetInt32(6);
             Metadata.ShowGroupsList = readQueryMetadata.GetBoolean(7);
             Metadata.SortFirstToLast = readQueryMetadata.GetBoolean(8);

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -176,7 +176,7 @@ public class Account : IDisposable
         set
         {
             //Remove Password If Empty (Decrypts)
-            if (string.IsNullOrEmpty(value))
+            if (string.IsNullOrWhiteSpace(value))
             {
                 //Create Temp Decrypted Database
                 var tempPath = $"{Path}.decrypt";
@@ -308,7 +308,7 @@ public class Account : IDisposable
             //Set Password
             if (IsEncrypted)
             {
-                if (string.IsNullOrEmpty(password))
+                if (string.IsNullOrWhiteSpace(password))
                 {
                     _loggedIn = false;
                     return false;
@@ -514,13 +514,13 @@ public class Account : IDisposable
                 RGBA = readQueryTransactions.IsDBNull(7) ? "" : readQueryTransactions.GetString(7),
                 UseGroupColor = readQueryTransactions.IsDBNull(11) ? false : readQueryTransactions.GetBoolean(11),
                 RepeatFrom = readQueryTransactions.IsDBNull(9) ? -1 : readQueryTransactions.GetInt32(9),
-                RepeatEndDate = readQueryTransactions.IsDBNull(10) ? null : (string.IsNullOrEmpty(readQueryTransactions.GetString(10)) ? null : DateOnly.Parse(readQueryTransactions.GetString(10), new CultureInfo("en-US", false))),
+                RepeatEndDate = readQueryTransactions.IsDBNull(10) ? null : (string.IsNullOrWhiteSpace(readQueryTransactions.GetString(10)) ? null : DateOnly.Parse(readQueryTransactions.GetString(10), new CultureInfo("en-US", false))),
                 Notes = readQueryTransactions.IsDBNull(12) ? "" : readQueryTransactions.GetString(12),
-                Tags = readQueryTransactions.IsDBNull(13) ? new List<string>() : (string.IsNullOrEmpty(readQueryTransactions.GetString(13)) ? new List<string>() : readQueryTransactions.GetString(13).Split(',').ToList())
+                Tags = readQueryTransactions.IsDBNull(13) ? new List<string>() : (string.IsNullOrWhiteSpace(readQueryTransactions.GetString(13)) ? new List<string>() : readQueryTransactions.GetString(13).Split(',').ToList())
             };
             Tags.AddRange(transaction.Tags.Where(t => !Tags.Contains(t)));
             var receiptString = readQueryTransactions.IsDBNull(8) ? "" : readQueryTransactions.GetString(8);
-            if (!string.IsNullOrEmpty(receiptString))
+            if (!string.IsNullOrWhiteSpace(receiptString))
             {
                 transaction.Receipt = SixLabors.ImageSharp.Image.Load(Convert.FromBase64String(receiptString));
             }
@@ -1320,7 +1320,7 @@ public class Account : IDisposable
             amount = Math.Abs(amount);
             //Get RGBA
             var rgba = fields[8];
-            if (string.IsNullOrEmpty(rgba))
+            if (string.IsNullOrWhiteSpace(rgba))
             {
                 rgba = defaultTransactionRGBA;
             }
@@ -1357,14 +1357,14 @@ public class Account : IDisposable
                 {
                     Name = groupName,
                     Description = groupDescription,
-                    RGBA = string.IsNullOrEmpty(groupRGBA) ? defaultGroupRGBA : groupRGBA
+                    RGBA = string.IsNullOrWhiteSpace(groupRGBA) ? defaultGroupRGBA : groupRGBA
                 };
                 if (await AddGroupAsync(group))
                 {
                     importResult.NewGroupIds.Add(group.Id);
                 }
             }
-            var tags = fields[14].Split(',').Where(x => !string.IsNullOrEmpty(x));
+            var tags = fields[14].Split(',').Where(x => !string.IsNullOrWhiteSpace(x));
             //Add Transaction
             var transaction = new Transaction(id)
             {
@@ -1432,7 +1432,7 @@ public class Account : IDisposable
             {
                 var t = new Transaction(NextAvailableTransactionId)
                 {
-                    Description = string.IsNullOrEmpty(transaction.Name) ? (string.IsNullOrEmpty(transaction.Memo) ? _("N/A") : transaction.Memo) : transaction.Name,
+                    Description = string.IsNullOrWhiteSpace(transaction.Name) ? (string.IsNullOrWhiteSpace(transaction.Memo) ? _("N/A") : transaction.Memo) : transaction.Name,
                     Date = DateOnly.FromDateTime(transaction.Date),
                     Type = transaction.Amount > 0 ? TransactionType.Income : TransactionType.Expense,
                     Amount = Math.Abs(transaction.Amount),
@@ -1494,7 +1494,7 @@ public class Account : IDisposable
                 var group = Groups.Values.FirstOrDefault(x => x.Name == transaction.Category);
                 var t = new Transaction(NextAvailableTransactionId)
                 {
-                    Description = string.IsNullOrEmpty(transaction.Memo) ? _("N/A") : transaction.Memo,
+                    Description = string.IsNullOrWhiteSpace(transaction.Memo) ? _("N/A") : transaction.Memo,
                     Date = DateOnly.FromDateTime(transaction.Date),
                     Type = transaction.Amount > 0 ? TransactionType.Income : TransactionType.Expense,
                     Amount = Math.Abs(transaction.Amount),
@@ -1736,7 +1736,7 @@ public class Account : IDisposable
                             {
                                 var hex = "#32"; //120
                                 var rgba = pair.Value.UseGroupColor ? Groups[pair.Value.GroupId <= 0 ? 0u : (uint)pair.Value.GroupId].RGBA : pair.Value.RGBA;
-                                if (string.IsNullOrEmpty(rgba))
+                                if (string.IsNullOrWhiteSpace(rgba))
                                 {
                                     hex = "#32FFFFFF";
                                 }
@@ -1970,7 +1970,7 @@ public class Account : IDisposable
             foreach (var pair in data.OrderBy(x => Groups[x.Key].Name == _("Ungrouped") ? " " : Groups[x.Key].Name))
             {
                 var hex = "#FF"; //255
-                var rgba = string.IsNullOrEmpty(Groups[pair.Key].RGBA) ? Configuration.Current.GroupDefaultColor : Groups[pair.Key].RGBA;
+                var rgba = string.IsNullOrWhiteSpace(Groups[pair.Key].RGBA) ? Configuration.Current.GroupDefaultColor : Groups[pair.Key].RGBA;
                 if (rgba.StartsWith("#"))
                 {
                     rgba = rgba.Remove(0, 1);

--- a/NickvisionMoney.Shared/Models/Account.cs
+++ b/NickvisionMoney.Shared/Models/Account.cs
@@ -176,7 +176,7 @@ public class Account : IDisposable
         set
         {
             //Remove Password If Empty (Decrypts)
-            if (string.IsNullOrWhiteSpace(value))
+            if (string.IsNullOrEmpty(value))
             {
                 //Create Temp Decrypted Database
                 var tempPath = $"{Path}.decrypt";
@@ -308,7 +308,7 @@ public class Account : IDisposable
             //Set Password
             if (IsEncrypted)
             {
-                if (string.IsNullOrWhiteSpace(password))
+                if (string.IsNullOrEmpty(password))
                 {
                     _loggedIn = false;
                     return false;

--- a/NickvisionMoney.Shared/Models/AccountMetadata.cs
+++ b/NickvisionMoney.Shared/Models/AccountMetadata.cs
@@ -216,7 +216,7 @@ public class AccountMetadata : ICloneable
             Mode = SqliteOpenMode.ReadOnly,
             Pooling = false
         };
-        if (!string.IsNullOrEmpty(password))
+        if (!string.IsNullOrWhiteSpace(password))
         {
             connectionString.Password = password;
         }

--- a/NickvisionMoney.Shared/Models/AccountMetadata.cs
+++ b/NickvisionMoney.Shared/Models/AccountMetadata.cs
@@ -216,7 +216,7 @@ public class AccountMetadata : ICloneable
             Mode = SqliteOpenMode.ReadOnly,
             Pooling = false
         };
-        if (!string.IsNullOrWhiteSpace(password))
+        if (!string.IsNullOrEmpty(password))
         {
             connectionString.Password = password;
         }

--- a/NickvisionMoney.Shared/Models/AccountMetadata.cs
+++ b/NickvisionMoney.Shared/Models/AccountMetadata.cs
@@ -243,8 +243,8 @@ public class AccountMetadata : ICloneable
             result.Name = readQueryMetadata.GetString(1);
             result.AccountType = (AccountType)readQueryMetadata.GetInt32(2);
             result.UseCustomCurrency = readQueryMetadata.GetBoolean(3);
-            result.CustomCurrencySymbol = string.IsNullOrEmpty(readQueryMetadata.GetString(4)) ? null : readQueryMetadata.GetString(4);
-            result.CustomCurrencyCode = string.IsNullOrEmpty(readQueryMetadata.GetString(5)) ? null : readQueryMetadata.GetString(5);
+            result.CustomCurrencySymbol = string.IsNullOrWhiteSpace(readQueryMetadata.GetString(4)) ? null : readQueryMetadata.GetString(4);
+            result.CustomCurrencyCode = string.IsNullOrWhiteSpace(readQueryMetadata.GetString(5)) ? null : readQueryMetadata.GetString(5);
             result.DefaultTransactionType = (TransactionType)readQueryMetadata.GetInt32(6);
             result.ShowGroupsList = readQueryMetadata.GetBoolean(7);
             result.SortFirstToLast = readQueryMetadata.GetBoolean(8);


### PR DESCRIPTION
Decimal and group separators are not touched - as discussed they can be white space.
Currency name and symbol are also left untouched, but I think they cannot be white space.

Fixes #730